### PR TITLE
Replace config.js with less-watch-compiler.config.json

### DIFF
--- a/less-watch-compiler.js
+++ b/less-watch-compiler.js
@@ -21,7 +21,7 @@ var sys = require('util')
   , data;
 
 // See if folder cwd contains 
-data = fs.readFileSync('config.json');
+data = fs.readFileSync('less-watch-compiler.config.json');
 extend(true, lessWatchCompilerUtils.config, JSON.parse(data));
 fs.exists(cwd+'/less-watch-compiler.config.json', function(exists) {
   if (exists) {


### PR DESCRIPTION
When running `less-watch-compiler` with `less-watch-compiler.config.json` in the same dir as described in the readme, it produces an error, because `config.json` does not exist.