### PR TITLE
fixed var filename not to include the dirname, in order to get proper…

### DIFF
--- a/lib/lessWatchCompilerUtils.js
+++ b/lib/lessWatchCompilerUtils.js
@@ -115,9 +115,9 @@ define(function ( require ) {
             // Here's where we run the less compiler
             compileCSS: function(file, test){
                 var dirname = path.dirname(file).replace(lessWatchCompilerUtilsModule.config.watchFolder, "") + "/";
-                var filename = dirname +path.basename(file, path.extname(file));
+                var filename = path.basename(file, path.extname(file));
                 var minifiedFlag = (lessWatchCompilerUtilsModule.config.minified === false)? '':'-x';
-                var command = 'lessc'+' '+ minifiedFlag +' '+file.replace(/\s+/g,'\\ ')+' > '+lessWatchCompilerUtilsModule.config.outputFolder+filename.replace(/\s+/g,'\\ ')+'.css';
+                var command = 'lessc'+' '+ minifiedFlag +' '+file.replace(/\s+/g,'\\ ')+' > '+lessWatchCompilerUtilsModule.config.outputFolder+ '/' +filename.replace(/\s+/g,'\\ ')+'.css';
                 // Run the command
                 if (!test)
                   exec(command, function (error, stdout, stderr){
@@ -162,6 +162,6 @@ define(function ( require ) {
 
 
         }
- 
+
         return lessWatchCompilerUtilsModule;
 });


### PR DESCRIPTION
Fixes #

- [ ] Semantic naming
- [ ] Clear and concise comments
- [ ] Adequate tests

Changes proposed in this pull request:
-
-
-


… outputFolder path when executing 'var command'