### PR TITLE
add .min to file name when minified option is set to true

### DIFF
--- a/lib/lessWatchCompilerUtils.js
+++ b/lib/lessWatchCompilerUtils.js
@@ -118,7 +118,7 @@ define(function ( require ) {
                 var filename = path.basename(file, path.extname(file));
                 var minifiedFlag = (lessWatchCompilerUtilsModule.config.minified === false)? '':' -x';
                 var sourceMap = (lessWatchCompilerUtilsModule.config.sourceMap)? ' --source-map' :''
-                var command = 'lessc'+sourceMap+minifiedFlag +' '+file.replace(/\s+/g,'\\ ')+' '+lessWatchCompilerUtilsModule.config.outputFolder+ '/' +filename.replace(/\s+/g,'\\ ')+'.css';
+                var command = 'lessc'+sourceMap+minifiedFlag +' '+file.replace(/\s+/g,'\\ ')+' '+lessWatchCompilerUtilsModule.config.outputFolder+ '/' +filename.replace(/\s+/g,'\\ ')+(lessWatchCompilerUtilsModule.config.minified ? '.min' : '')+'.css';
                 // Run the command
                 if (!test)
                   exec(command, function (error, stdout, stderr){

--- a/tests/test.js
+++ b/tests/test.js
@@ -47,7 +47,7 @@ describe('lessWatchCompilerUtils Module API', function(){
         it('should run the correct command with minified flag', function(){
             lessWatchCompilerUtils.config.outputFolder = "testFolder";
             lessWatchCompilerUtils.config.minified = true;
-            assert.equal("lessc -x test testFolder/test.css", lessWatchCompilerUtils.compileCSS("test", true));
+            assert.equal("lessc -x test testFolder/test.min.css", lessWatchCompilerUtils.compileCSS("test", true));
         });
         it('should run the correct command with sourceMap flag', function(){
             lessWatchCompilerUtils.config.outputFolder = "testFolder";


### PR DESCRIPTION
Fixes #

- [x] Semantic naming
- [x] Clear and concise comments
- [x] Adequate tests

Changes proposed in this pull request:
- If minified option is true, output file should have the .min.css extension

