### PR TITLE
fix watch underscore files

### DIFF
--- a/dist/lib/lessWatchCompilerUtils.js
+++ b/dist/lib/lessWatchCompilerUtils.js
@@ -113,7 +113,7 @@ define(function (require) {
       var filename = path.basename(f);
       var extension = path.extname(f),
           allowedExtensions = lessWatchCompilerUtilsModule.config.allowedExtensions || defaultAllowedExtensions;
-      if (filename.substr(0, 1) == '_' || filename.substr(0, 1) == '.' || filename == '' || allowedExtensions.indexOf(extension) == -1) return true;else {
+      if (filename.substr(0, 1) == '.' || filename == '' || allowedExtensions.indexOf(extension) == -1) return true;else {
         return false;
       }
     },


### PR DESCRIPTION
Fixes #

- [x] Semantic naming
- [x] Clear and concise comments
- [ ] Adequate tests

Changes proposed in this pull request:
- Underscore files should be watched because usually you import them on compiled .less
- Underscore files should not be compiled that's fine
