### PR TITLE
Exit with code 1 on error in run-once mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ less-watch-compiler
 * By default, "sourceMap" is turned off. You can generating sourcemap to true by adding `"sourceMap":true` in the config file.
 * By default, this script only compiles files with `.less` extension. More file extensions can be added by modifying the `allowedExtensions` array in `config.json`.
 * Files that start with underscores `_style.css` or period `.style.css` are ignored. This behavior can be changed in the `filterFiles()` function.
+* When `--run-once` used, compilation will fail on first error
 
 ### Using the source files
 Alternativelly, you can checkout the code and run things locally like this:

--- a/src/lib/lessWatchCompilerUtils.js
+++ b/src/lib/lessWatchCompilerUtils.js
@@ -102,8 +102,11 @@ define(function (require) {
       // console.log(command)
       if (!test)
         exec(command, function (error, stdout, stderr) {
-          if (error !== null)
+          if (error !== null) {
             console.log(error);
+            if (lessWatchCompilerUtilsModule.config.runOnce)
+              process.exit(1);
+          }
           if (stdout)
             console.error(stdout);
         });


### PR DESCRIPTION
Fixes #
Exit process if error found in runOnce mode 

- [ ] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
- call process.exit in error callback if runOnce active

