### PR TITLE
possibility to pass on --js to lessc enabling inline JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ less-watch-compiler
     "mainFile": "<main-file>",   
     "sourceMap": false,
     "plugins": "plugin1,plugin2",
-    "runOnce": false
+    "runOnce": false,
+    "inlineJs": true
 }
 ```
 

--- a/less-watch-compiler.sample.config.json
+++ b/less-watch-compiler.sample.config.json
@@ -1,5 +1,6 @@
 {
     "allowedExtensions":[".less"],
+    "inlineJs": true,
     "minified": true,
     "sourceMap": true,
     "plugins": "plugin1,plugin2",

--- a/src/lib/lessWatchCompilerUtils.js
+++ b/src/lib/lessWatchCompilerUtils.js
@@ -92,12 +92,13 @@ define(function (require) {
       var dirname = path.dirname(file).replace(lessWatchCompilerUtilsModule.config.watchFolder, "")
       dirname = dirname === '.'? '' : dirname;
       var filename = path.basename(file, path.extname(file));
+      var inlineJsFlag = lessWatchCompilerUtilsModule.config.inlineJs ? ' --js' : '';
       var minifiedFlag = lessWatchCompilerUtilsModule.config.minified ? ' -x' : '';
       var sourceMap = (lessWatchCompilerUtilsModule.config.sourceMap) ? ' --source-map' : '';
       var plugins = (lessWatchCompilerUtilsModule.config.plugins) ? ' --' + lessWatchCompilerUtilsModule.config.plugins.split(',').join(' --') : '';
       var outputFilePath = lessWatchCompilerUtilsModule.config.outputFolder  + dirname + '/' + filename.replace(/\s+/g, '\\ ') +
         (lessWatchCompilerUtilsModule.config.minified ? '.min' : '') + '.css';
-      var command = 'lessc' + sourceMap + minifiedFlag + plugins + ' ' + file.replace(/\s+/g, '\\ ') + ' ' + outputFilePath;
+      var command = 'lessc' + sourceMap + inlineJsFlag + minifiedFlag + plugins + ' ' + file.replace(/\s+/g, '\\ ') + ' ' + outputFilePath;
       // Run the command
       //  console.log(command)
       if (!test)

--- a/tests/lessWatchCompilerUtils.js
+++ b/tests/lessWatchCompilerUtils.js
@@ -43,20 +43,29 @@ describe('lessWatchCompilerUtils Module API', function () {
             it('compileCSS() function should be there', function () {
                 assert.equal("function", typeof (lessWatchCompilerUtils.compileCSS));
             });
-            it('should run the correct command with minified flag', function () {
+            it('should run the correct command with minified flag', function () {   
                 lessWatchCompilerUtils.config.outputFolder = "testFolder";
                 lessWatchCompilerUtils.config.minified = true;
+                lessWatchCompilerUtils.config.inlineJs = false;
                 assert.equal("lessc -x test.less testFolder/test.min.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);
+            });
+            it('should run the correct command with inlineJs flag', function () {
+                lessWatchCompilerUtils.config.outputFolder = "testFolder";
+                lessWatchCompilerUtils.config.minified = false;
+                lessWatchCompilerUtils.config.inlineJs = true;
+                assert.equal("lessc --js test.less testFolder/test.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);
             });
             it('should run the correct command with sourceMap flag', function () {
                 lessWatchCompilerUtils.config.outputFolder = "testFolder";
                 lessWatchCompilerUtils.config.minified = false;
+                lessWatchCompilerUtils.config.inlineJs = false;
                 lessWatchCompilerUtils.config.sourceMap = true;
                 assert.equal("lessc --source-map test.less testFolder/test.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);
             });
             it('should run the correct command with 1 plugin', function () {
                 lessWatchCompilerUtils.config.outputFolder = "testFolder";
                 lessWatchCompilerUtils.config.minified = false;
+                lessWatchCompilerUtils.config.inlineJs = false;
                 lessWatchCompilerUtils.config.sourceMap = false;
                 lessWatchCompilerUtils.config.plugins = "plugin1";
                 assert.equal("lessc --plugin1 test.less testFolder/test.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);
@@ -64,6 +73,7 @@ describe('lessWatchCompilerUtils Module API', function () {
             it('should run the correct command with 2 plugins', function () {
                 lessWatchCompilerUtils.config.outputFolder = "testFolder";
                 lessWatchCompilerUtils.config.minified = false;
+                lessWatchCompilerUtils.config.inlineJs = false;
                 lessWatchCompilerUtils.config.sourceMap = false;
                 lessWatchCompilerUtils.config.plugins = "plugin1,plugin2";
                 assert.equal("lessc --plugin1 --plugin2 test.less testFolder/test.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);
@@ -72,6 +82,7 @@ describe('lessWatchCompilerUtils Module API', function () {
             it('should run the correct command with minified flag', function () {
                 lessWatchCompilerUtils.config.outputFolder = "testFolder";
                 lessWatchCompilerUtils.config.minified = true;
+                lessWatchCompilerUtils.config.inlineJs = false;
                 lessWatchCompilerUtils.config.sourceMap = false;
                 lessWatchCompilerUtils.config.plugins = false;
                 assert.equal("lessc -x test.less testFolder/test.min.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);


### PR DESCRIPTION
Fixes #

- [yes] Did you add adequate test and make sure they pass by running `npm run test`
- [yes] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
Added configuration option to pass --js to lessc, enabling inline JavaScript which is required when compiling projects not yet upgraded to use @plugin for less i.e. Antd.
-
-

