### PR TITLE
Better path resolving

### DIFF
--- a/src/less-watch-compiler.js
+++ b/src/less-watch-compiler.js
@@ -89,8 +89,12 @@ function init(){
     console.log('\t\t less-watch-compiler less css');
     process.exit(1);
   }
+  
+  lessWatchCompilerUtils.config.watchFolder = path.resolve(lessWatchCompilerUtils.config.watchFolder);
+  lessWatchCompilerUtils.config.outputFolder = path.resolve(lessWatchCompilerUtils.config.outputFolder);
+
   if (lessWatchCompilerUtils.config.mainFile) {
-    mainFilePath = [lessWatchCompilerUtils.config.watchFolder, lessWatchCompilerUtils.config.mainFile].join('/');
+    mainFilePath = path.resolve(lessWatchCompilerUtils.config.watchFolder, lessWatchCompilerUtils.config.mainFile);
     fs.exists(mainFilePath, function(exists) {
       if (!exists){
         console.log("Main file " + mainFilePath+" does not exist.");

--- a/tests/lessWatchCompilerUtils.js
+++ b/tests/lessWatchCompilerUtils.js
@@ -97,7 +97,7 @@ describe('lessWatchCompilerUtils Module API', function () {
                 lessWatchCompilerUtils.config.sourceMap = false;
                 lessWatchCompilerUtils.config.plugins = false;
 
-                // Walker will always paths relative to watchFolder
+                // Walker will always return paths relative to watchFolder
                 assert.equal(lessWatchCompilerUtils.resolveOutputPath('inputFolder/inner/evenmore/afile.less'), 'testFolder/nested/evenmore/afile.min.css');
             });
 

--- a/tests/lessWatchCompilerUtils.js
+++ b/tests/lessWatchCompilerUtils.js
@@ -87,7 +87,33 @@ describe('lessWatchCompilerUtils Module API', function () {
                 lessWatchCompilerUtils.config.plugins = false;
                 assert.equal("lessc -x test.less testFolder/test.min.css", lessWatchCompilerUtils.compileCSS("test.less", true).command);
             });
-        })
+        });
+        describe('resolveOutputPath()', function () {	
+            it('should resolve filepaths correctly', function () {
+                lessWatchCompilerUtils.config.watchFolder = "./inputFolder/inner";
+                lessWatchCompilerUtils.config.outputFolder = "./testFolder/nested";
+                lessWatchCompilerUtils.config.minified = true;
+                lessWatchCompilerUtils.config.enableJs = false;
+                lessWatchCompilerUtils.config.sourceMap = false;
+                lessWatchCompilerUtils.config.plugins = false;
+
+                // Walker will always paths relative to watchFolder
+                assert.equal(lessWatchCompilerUtils.resolveOutputPath('inputFolder/inner/evenmore/afile.less'), 'testFolder/nested/evenmore/afile.min.css');
+            });
+
+            it('should resolve always put output files in output folder', function () {
+                lessWatchCompilerUtils.config.watchFolder = "./inputFolder/inner";
+                lessWatchCompilerUtils.config.outputFolder = "./testFolder/nested";
+                lessWatchCompilerUtils.config.minified = true;
+                lessWatchCompilerUtils.config.enableJs = false;
+                lessWatchCompilerUtils.config.sourceMap = false;
+                lessWatchCompilerUtils.config.plugins = false;
+
+                // Main file is relative to watchFolder as well, but can be a relative path
+                // it should however always land in the destination folder
+                assert.equal(lessWatchCompilerUtils.resolveOutputPath('inputFolder/inner/../afile.less'), 'testFolder/nested/afile.min.css');
+            });
+        });
         describe('filterFiles()', function () {
             it('filterFiles() function should be there', function () {
                 assert.equal("function", typeof (lessWatchCompilerUtils.filterFiles));


### PR DESCRIPTION
Fixes #60 

- [X] Did you add adequate test and make sure they pass by running `npm run test`
- [ ] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
- Added better path resolving system. 
- Allows main file to be outside `source_dir`, outputs it to root of `output_dir`. Does *not* make it watchable, I didn't want to make this PR too overblown

I did not touch other path related resolving parts, which may not resolve some of the path related issues.
Also to not touch other testcases it uses relative paths as arguments passed to `lessc`, I can change that to use absolute paths instead if anybody is interested.