### PR TITLE
Initialization function optimization

### DIFF
--- a/src/less-watch-compiler.js
+++ b/src/less-watch-compiler.js
@@ -150,9 +150,12 @@ function init(){
         }
       }
     },
+    // init function
     function(f){
-      // console.log("mainFilePath :" +mainFilePath)
-      lessWatchCompilerUtils.compileCSS(mainFilePath || f);
+      if (!mainFilePath || mainFilePath === f) {
+        // compile each file when main file is missing or compile main file only once
+        lessWatchCompilerUtils.compileCSS(f);
+      }
     }
   );
 }


### PR DESCRIPTION
During the startup an initialization function that triggers compilation is called for each file in watch folder. This can spawn many node processes that in my case consumed whole memory. When the main file is defined, initialization function compiles it for each file what is not necessary.

In this PR I am compiling main file during startup only once and retaining the logic when the main file is not defined.