### PR TITLE
fix: fix problem where CLI options are ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,6 @@ tests/css
 .idea/
 node_modules
 .vscode/
-less-watch-compiler.config.json
+./less-watch-compiler.config.json
 build/
 dist/

--- a/src/less-watch-compiler.js
+++ b/src/less-watch-compiler.js
@@ -21,14 +21,14 @@ var sys = require('util')
   , cwd = sh.pwd()
   , data
   , mainFilePath = undefined
-  , program = require('commander')
+  , cmdr = require('commander')
   , packagejson = require('../package.json')
   , events = require('events');
 
 //bypass maxlistener errors because more files means more listeners #90
 events.EventEmitter.defaultMaxListeners = 0;
 
-program
+cmdr
   .version(packagejson.version)
   .usage('[options] <source_dir> <destination_dir> [main_file_name]')
   .option('--main-file <file>', "Specify <file> as the file to always re-compile e.g. '--main-file style.less'.")
@@ -41,7 +41,9 @@ program
   .option('--less-args <less-arg1>=<less-arg1-value>,<less-arg1>=<less-arg2-value>', 'Less.js Option: To specify any other less options e.g. \'--less-args math=strict,strict-units=on,include-path=.\/dir1\\;.\/dir2\'.')
   .parse(process.argv);
 
-// Check if configuration file exists
+const program = cmdr.opts();
+
+  // Check if configuration file exists
   var configPath = program.config ? (path.isAbsolute(program.config))? program.config : (cwd + path.sep + program.config): "less-watch-compiler.config.json";
 
   fs.access(configPath, fs.constants.F_OK, (err) => {
@@ -56,9 +58,9 @@ program
 
 
 function init(){
-  if (program.args[0])   lessWatchCompilerUtils.config.watchFolder =  program.args[0];
-  if (program.args[1])   lessWatchCompilerUtils.config.outputFolder =  program.args[1];
-  if (program.args[2])   lessWatchCompilerUtils.config.mainFile =  program.args[2];
+  if (cmdr.args[0])   lessWatchCompilerUtils.config.watchFolder =  cmdr.args[0];
+  if (cmdr.args[1])   lessWatchCompilerUtils.config.outputFolder =  cmdr.args[1];
+  if (cmdr.args[2])   lessWatchCompilerUtils.config.mainFile =  cmdr.args[2];
   if (program.mainFile)   lessWatchCompilerUtils.config.mainFile =  program.mainFile;
   if (program.sourceMap) lessWatchCompilerUtils.config.sourceMap = program.sourceMap;
   if (program.plugins) lessWatchCompilerUtils.config.plugins = program.plugins;

--- a/tests/less-watch-compile.js
+++ b/tests/less-watch-compile.js
@@ -1,0 +1,44 @@
+const { doesNotMatch } = require("assert");
+
+let assert = require("assert"),
+    filesearch = require('../dist/lib/filesearch.js'),
+    sh = require('shelljs'),
+    cwd = sh.pwd().toString(),
+    path= require('path'),
+    exec = require('child_process').exec;
+
+    describe('less-watch-compiler.js', function () {
+        describe('recognize these options:', function () {
+    
+            describe('--run-once parameter', function () {
+                it('exit after once',  async () =>  {
+                    let result = await  cli(['--run-once','tests/less', 'tests/css'], '.');
+                    assert.equal(result.code, 0);
+                });
+            })
+
+            describe('--config parameter', function () {
+                it('should load a config json',  async () =>  {
+                    let result = await  cli(['--config','tests/less-watch-compiler.config.json'], '.');
+                    assert.equal(result.code, 0);
+                });
+            })
+    
+        })
+    })
+
+
+
+function cli(args) {
+  return new Promise(resolve => { 
+    const command = `node ${path.resolve('src/less-watch-compiler.js')} ${args.join(' ')}`;
+    exec(command,
+    null, 
+    (error, stdout, stderr) => { resolve({
+    code: error && error.code ? error.code : 0,
+    error,
+    stdout,
+    stderr })
+  })
+})
+}

--- a/tests/less-watch-compiler.config.json
+++ b/tests/less-watch-compiler.config.json
@@ -1,0 +1,10 @@
+{
+    "allowedExtensions":[".less"],
+    "enableJs": false,
+    "runOnce": true,
+    "minified": false,
+    "sourceMap": false,
+    "plugins": "",
+    "watchFolder": "tests/less",
+    "outputFolder": "tests/css"
+}


### PR DESCRIPTION
Since the upgrade to the latest version of commander, all command line options stopped working
because the reference to commander options had changed. This commit will fix them. Tests were also
added.

Fixes #136 #137

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

