### PR TITLE
fix(filesearch): Implied extension @import statement #117

### DIFF
--- a/src/lib/filesearch.js
+++ b/src/lib/filesearch.js
@@ -18,6 +18,12 @@ define(function (require){
                 while (m = re.exec(fileContent)){
                     let [ , , filename ] = m;
                     // console.log('found import ' + filename);
+
+                    if (path.extname(filename).length < 1) {
+                        // console.log("The imported file does not have an explicit extension, we will assume it's .less", filename);
+                        filename = filename + ".less";
+                    }
+
                     if (m) files.push(filename);
                 }
                 return files;

--- a/test/filesearch.js
+++ b/test/filesearch.js
@@ -16,7 +16,7 @@ describe('filesearch Module', function () {
 
             it('should search through a file and find LESS @import statements ', function (done) {
                 var file = "./test/less/test.less";
-                var result = ['lvl1.less', 'lvl2/lvl2.less', 'lvl2/lvl3/lvl3.less', 'hidden/_hidden.less', 'hidden/.hidden2.less'],
+                var result = ['lvl1.less', 'lvl2/lvl2.less', 'lvl2/lvl2_no_extension.less', 'lvl2/lvl3/lvl3.less', 'hidden/_hidden.less', 'hidden/.hidden2.less'],
                     filesearchresult = filesearch.findLessImportsInFile(file);
                 assert.equal(result.toString(), filesearchresult.toString());
                 done();

--- a/test/less/lvl2/lvl2_no_extension.less
+++ b/test/less/lvl2/lvl2_no_extension.less
@@ -1,0 +1,3 @@
+.lvl2_no_extension {
+  display: inline;
+}

--- a/test/less/test.less
+++ b/test/less/test.less
@@ -8,6 +8,7 @@ Test Comments
 }
 @import 'lvl1.less';
 @import "lvl2/lvl2.less";
+@import "lvl2/lvl2_no_extension";
 @import "lvl2/lvl3/lvl3.less";
 @import "hidden/_hidden.less";
 @import "hidden/.hidden2.less";


### PR DESCRIPTION
Fixing a bug where .less extension is not optional with some @import statements in certain directory
structures. This fix checks if the @import statement has an extension available, if an extension is
not provided we assume the default as .less.

fix #117

Fixes #

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [ ] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
- Instead of implying `.less` extension for `@import` statements make it the default

Steps to recreate issue:

Directory Structure:
```
.
├── a
│   ├── b
│   │   └── c
│   │       └── d.less
│   ├── e.less
│   └── index.less
```

Command:
`npx less-watch-compiler ./a ./dist`