### PR TITLE
Deletion of an extra "the"

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ less-watch-compiler src dist main.less
 ```
 
 ## Configuration File
-By default the the configuration file is loaded from ./less-watch-compiler.config.json but can also be specified by the --config <file> option.
+By default the configuration file is loaded from ./less-watch-compiler.config.json but can also be specified by the --config <file> option.
 
 #### Example using the project tree laid out in the previous example
 


### PR DESCRIPTION
Fixes #

- [ ] Did you add adequate test and make sure they pass by running `npm run test`
- [ ] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
-
-
-

