### PR TITLE
Fix hidden file compilation with includeHidden flag

### DIFF
--- a/src/less-watch-compiler.js
+++ b/src/less-watch-compiler.js
@@ -66,7 +66,7 @@ function init(){
   if (programOption.sourceMap) lessWatchCompilerUtils.config.sourceMap = programOption.sourceMap;
   if (programOption.plugins) lessWatchCompilerUtils.config.plugins = programOption.plugins;
   if (programOption.runOnce) lessWatchCompilerUtils.config.runOnce = programOption.runOnce;
-  if (programOption.inludeHidden) lessWatchCompilerUtils.config.includeHidden = programOption.includeHidden;
+  if (programOption.includeHidden) lessWatchCompilerUtils.config.includeHidden = programOption.includeHidden;
   if (programOption.enableJs) lessWatchCompilerUtils.config.enableJs = programOption.enableJs;
   if (programOption.lessArgs) lessWatchCompilerUtils.config.lessArgs = programOption.lessArgs;
 

--- a/src/lib/lessWatchCompilerUtils.js
+++ b/src/lib/lessWatchCompilerUtils.js
@@ -96,9 +96,8 @@ define(function (require) {
 
       var outputFilePath = this.resolveOutputPath(file);
 
-      // As a rule, we don't compile hidden files for now. If we encounter one,
-      // just return.
-      if (fileSearch.isHiddenFile(outputFilePath)) return
+      // Skip compiling hidden files unless includeHidden flag is enabled
+      if (fileSearch.isHiddenFile(file) && !lessWatchCompilerUtilsModule.config.includeHidden) return
 
       var enableJsFlag = lessWatchCompilerUtilsModule.config.enableJs ? ' --js' : '';
       var minifiedFlag = lessWatchCompilerUtilsModule.config.minified ? ' -x' : '';

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -111,6 +111,21 @@ describe('lessWatchCompilerUtils Module API', function () {
                 };
                 assert.equal("lessc --math=strict --strict-units=on --include-path=./dir1\;./dir2 \"test.less\" \"testFolder/test.css\"", lessWatchCompilerUtils.compileCSS("test.less", true).command);
             });
+
+            it('should not compile hidden files by default', function () {
+                lessWatchCompilerUtils.config = {
+                    outputFolder: "testFolder"
+                };
+                assert.equal(undefined, lessWatchCompilerUtils.compileCSS("_test.less", true));
+            });
+
+            it('should compile hidden files when includeHidden flag is set', function () {
+                lessWatchCompilerUtils.config = {
+                    outputFolder: "testFolder",
+                    includeHidden: true
+                };
+                assert.equal("lessc \"_test.less\" \"testFolder/_test.css\"", lessWatchCompilerUtils.compileCSS("_test.less", true).command);
+            });
         });
         describe('resolveOutputPath()', function () {
             // reset config


### PR DESCRIPTION
## Summary
- honor `includeHidden` option in compiler so hidden LESS files are processed when requested
- fix CLI option handling for `--include-hidden`
- add tests covering hidden file compilation behavior

## Testing
- `npx yarn@1 run build`
- `npx yarn@1 run clean`
- `npx mocha --exit`


------
https://chatgpt.com/codex/tasks/task_e_68a47980951c8323b226fe21efba8f03