### PR TITLE
Specify Netlify build image and Node version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+
+[build.environment]
+  NETLIFY_BUILD_IMAGE = "focal"
+  NODE_VERSION = "18"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "less": "^4.0.0",
     "shelljs": ">= 0.4.0"
   },
-  "engine": "node 0.10.26",
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "@types/commander": "2.12.2",
     "babel-cli": "6.26.0",


### PR DESCRIPTION
## Summary
- add `netlify.toml` to select supported Netlify build image and Node version
- define Node 18 engine requirement in `package.json`

## Testing
- `npx babel src --out-dir dist && (rm -R ./test/css || true) && mkdir ./test/css && npx mocha --exit`


------
https://chatgpt.com/codex/tasks/task_e_68a47bfdef148323b20f0269bb31f3d2