### PR TITLE
Compile LESS in-process via the less API — no more global lessc requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,7 @@ Parts of this script is modified from Mikeal Rogers's watch script (https://gith
 
 ## Prerequisites
 
-> The commands below may need to be prefixed with `sudo` depending upon your system
-
-Install [LESS](http://www.lesscss.org/) and make sure the `lessc` binary is accessible to the script. Installing LESS with the `-g`(global) flag will make the binary accessible to your system.
-
-### [yarn](https://yarnpkg.com/)
-
-```bash
-yarn global add less
-```
-
-### [npm](https://www.npmjs.com/)
-
-```bash
-npm install -g less
-```
+None beyond [Node.js](https://nodejs.org/) (>= 18). [LESS](http://www.lesscss.org/) is bundled as a dependency and compilation happens in-process — a separate global `lessc` installation is no longer required.
 
 ## Installation
 

--- a/dist/lib/lessWatchCompilerUtils.d.ts
+++ b/dist/lib/lessWatchCompilerUtils.d.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import lessOptions = require('./lessOptions');
 interface WalkOptions {
     ignoreDotFiles?: boolean;
     filter?: (filePath: string) => boolean;
@@ -14,8 +15,8 @@ interface InitCallback {
     (f: string): void;
 }
 interface CompileResult {
-    command: string;
     outputFilePath: string;
+    options: lessOptions.LessRenderOptions;
 }
 interface LessWatchCompilerConfig {
     watchFolder?: string;
@@ -35,8 +36,15 @@ declare const lessWatchCompilerUtilsModule: {
     config: LessWatchCompilerConfig;
     walk(dir: string, options: WalkOptions, callback: WalkCompleteCallback, initCallback?: InitCallback): void;
     watchTree(root: string, options: WalkOptions | WatchCallback, watchCallback?: WatchCallback, initCallback?: InitCallback): void;
-    getLessArgs(args: string): string;
     compileCSS(file: string, test?: boolean): CompileResult | undefined;
+    renderLess(file: string, outPath: string, options: lessOptions.LessRenderOptions): Promise<void>;
+    formatLessError(error: Error & {
+        line?: number;
+        column?: number;
+        filename?: string;
+        extract?: string[];
+        type?: string;
+    }): string;
     resolveOutputPath(filePath: string): string;
     filterFiles(f: string): boolean;
     getDateTime(): string;

--- a/dist/lib/lessWatchCompilerUtils.js
+++ b/dist/lib/lessWatchCompilerUtils.js
@@ -4,8 +4,10 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-const child_process_1 = require("child_process");
 const fileSearch = require("./filesearch");
+const lessOptions = require("./lessOptions");
+// The less package ships no type definitions
+const less = require('less');
 const cwd = process.cwd();
 const defaultAllowedExtensions = ['.less'];
 const filelist = [];
@@ -97,32 +99,64 @@ const lessWatchCompilerUtilsModule = {
             cb(filesMap, null, null, fileimportlist);
         }, initCallback);
     },
-    getLessArgs(args) {
-        const arr = args.split(',');
-        return ' --' + arr.join(' --');
-    },
     compileCSS(file, test) {
         const outputFilePath = this.resolveOutputPath(file);
         // Skip compiling hidden files unless includeHidden flag is enabled
         if (fileSearch.isHiddenFile(file) && !lessWatchCompilerUtilsModule.config.includeHidden)
             return;
-        const enableJsFlag = lessWatchCompilerUtilsModule.config.enableJs ? ' --js' : '';
-        const minifiedFlag = lessWatchCompilerUtilsModule.config.minified ? ' -x' : '';
-        const sourceMap = lessWatchCompilerUtilsModule.config.sourceMap ? ' --source-map' : '';
-        const lessArgs = lessWatchCompilerUtilsModule.config.lessArgs ? this.getLessArgs(lessWatchCompilerUtilsModule.config.lessArgs) : '';
-        const plugins = lessWatchCompilerUtilsModule.config.plugins ? ' --' + lessWatchCompilerUtilsModule.config.plugins.split(',').join(' --') : '';
-        const command = 'lessc' + lessArgs + sourceMap + enableJsFlag + minifiedFlag + plugins + ' ' + JSON.stringify(file) + ' ' + outputFilePath;
-        if (!test)
-            (0, child_process_1.exec)(command, (error, stdout) => {
-                if (error !== null) {
-                    console.log(error);
-                    if (lessWatchCompilerUtilsModule.config.runOnce)
-                        process.exit(1);
-                }
-                if (stdout)
-                    console.error(stdout);
+        const outPath = JSON.parse(outputFilePath);
+        const options = lessOptions.buildRenderOptions({
+            inputFilePath: file,
+            outputFilePath: outPath,
+            enableJs: lessWatchCompilerUtilsModule.config.enableJs,
+            minified: lessWatchCompilerUtilsModule.config.minified,
+            sourceMap: lessWatchCompilerUtilsModule.config.sourceMap,
+            lessArgs: lessWatchCompilerUtilsModule.config.lessArgs
+        });
+        if (!test) {
+            lessWatchCompilerUtilsModule
+                .renderLess(file, outPath, options)
+                .catch((error) => {
+                console.log(lessWatchCompilerUtilsModule.formatLessError(error));
+                if (lessWatchCompilerUtilsModule.config.runOnce)
+                    process.exit(1);
             });
-        return { command, outputFilePath };
+        }
+        return { outputFilePath, options };
+    },
+    async renderLess(file, outPath, options) {
+        const renderOptions = { ...options };
+        if (lessWatchCompilerUtilsModule.config.plugins) {
+            renderOptions.plugins = await lessOptions.loadPlugins(lessWatchCompilerUtilsModule.config.plugins, less, renderOptions);
+        }
+        const input = await fs_1.default.promises.readFile(file, 'utf8');
+        const result = await less.render(input, renderOptions);
+        await fs_1.default.promises.mkdir(path_1.default.dirname(path_1.default.resolve(outPath)), { recursive: true });
+        await fs_1.default.promises.writeFile(outPath, result.css, 'utf8');
+        if (result.map) {
+            await fs_1.default.promises.writeFile(outPath + '.map', result.map, 'utf8');
+        }
+    },
+    formatLessError(error) {
+        if (error.line === undefined && error.filename === undefined)
+            return String(error.stack || error.message || error);
+        const kind = error.type ? error.type + 'Error' : 'Error';
+        let message = kind + ': ' + error.message;
+        if (error.filename) {
+            message += ' in ' + error.filename;
+            if (error.line !== undefined)
+                message += ' on line ' + error.line + ', column ' + error.column + ':';
+        }
+        if (error.extract) {
+            const firstLine = error.line !== undefined ? error.line - 1 : 0;
+            message +=
+                '\n' +
+                    error.extract
+                        .filter((line) => line !== undefined)
+                        .map((line, index) => firstLine + index + ' ' + line)
+                        .join('\n');
+        }
+        return message;
     },
     resolveOutputPath(filePath) {
         const fullPath = path_1.default.resolve(filePath);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cz-conventional-changelog": "3.3.0",
     "eslint": "^10.7.0",
     "eslint-config-prettier": "^10.1.8",
+    "less-plugin-clean-css": "^1.6.0",
     "mocha": "^11.7.5",
     "prettier": "^3.9.5",
     "typescript": "^5.6.2",

--- a/src/lib/lessOptions.ts
+++ b/src/lib/lessOptions.ts
@@ -1,0 +1,223 @@
+import path from 'path';
+import os from 'os';
+
+/**
+ * Translation of this tool's config into options for less.render(), mirroring
+ * the argument handling of the lessc CLI (less/bin/lessc) so that compiling
+ * in-process produces byte-identical output to shelling out to lessc.
+ */
+
+export interface RenderOptionsInput {
+  inputFilePath: string;
+  outputFilePath: string;
+  enableJs?: boolean;
+  minified?: boolean;
+  sourceMap?: boolean;
+  lessArgs?: string;
+}
+
+export type LessRenderOptions = Record<string, unknown>;
+
+// Split on commas that are not inside parentheses, so values such as
+// modify-var='c=rgba(1, 2, 3, 0.5)' survive intact (issue #103)
+export function splitTopLevelCommas(value: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const ch of value) {
+    if (ch === '(') depth++;
+    else if (ch === ')' && depth > 0) depth--;
+    if (ch === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += ch;
+    }
+  }
+  if (current !== '') parts.push(current);
+  return parts;
+}
+
+function booleanValue(value: string | undefined): boolean {
+  if (value === undefined) return true;
+  return value !== 'off' && value !== 'false' && value !== '0';
+}
+
+// lessc's parseVariableOption: "name=value" into a variables object
+function parseVariableOption(option: string, variables: Record<string, string>): void {
+  const parts = option.split('=');
+  variables[parts[0].trim()] = parts.slice(1).join('=').trim();
+}
+
+function camelCase(key: string): string {
+  return key.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+/**
+ * Translate one k=v (or bare-flag) entry from the --less-args list onto the
+ * render options object, following lessc's own argument table.
+ */
+function applyLessArg(options: LessRenderOptions, entry: string): void {
+  const eq = entry.indexOf('=');
+  const key = (eq === -1 ? entry : entry.slice(0, eq)).trim().replace(/^-+/, '');
+  const value = eq === -1 ? undefined : entry.slice(eq + 1).replace(/^['"]|['"]$/g, '');
+
+  switch (key) {
+    case 'x':
+    case 'compress':
+      options.compress = booleanValue(value);
+      break;
+    case 'js':
+      options.javascriptEnabled = true;
+      break;
+    case 'no-js':
+      options.javascriptEnabled = false;
+      break;
+    case 'include-path':
+      // lessc splits on ; (always) and : (except when followed by a backslash, for Windows drive letters)
+      options.paths = (value || '').split(os.type().match(/Windows/) ? /:(?!\\)|;/ : /[:;]/).filter((p) => p !== '');
+      break;
+    case 'strict-imports':
+      options.strictImports = true;
+      break;
+    case 'insecure':
+      options.insecure = true;
+      break;
+    case 'ie-compat':
+      options.ieCompat = true;
+      break;
+    case 'l':
+    case 'lint':
+      options.lint = true;
+      break;
+    case 'rp':
+    case 'rootpath':
+      options.rootpath = (value || '').replace(/\\/g, '/');
+      break;
+    case 'relative-urls':
+      options.rewriteUrls = 'all';
+      break;
+    case 'ru':
+    case 'rewrite-urls':
+      options.rewriteUrls = value === undefined ? 'all' : value;
+      break;
+    case 'sm':
+    case 'strict-math':
+      options.math = booleanValue(value) ? 'strict' : 'always';
+      break;
+    case 'm':
+    case 'math':
+      options.math = value;
+      break;
+    case 'su':
+    case 'strict-units':
+      options.strictUnits = booleanValue(value);
+      break;
+    case 'global-var': {
+      const vars = (options.globalVars as Record<string, string>) || {};
+      if (value) parseVariableOption(value, vars);
+      options.globalVars = vars;
+      break;
+    }
+    case 'modify-var': {
+      const vars = (options.modifyVars as Record<string, string>) || {};
+      if (value) parseVariableOption(value, vars);
+      options.modifyVars = vars;
+      break;
+    }
+    case 'url-args':
+      options.urlArgs = value || '';
+      break;
+    case 'line-numbers':
+      options.dumpLineNumbers = value;
+      break;
+    case 'no-color':
+    case 's':
+    case 'silent':
+    case 'verbose':
+      // Presentation-only lessc flags; no render-option equivalent
+      break;
+    default:
+      // Unknown keys pass through camelCased with on/off coercion, matching
+      // the permissive spirit of the previous string-built lessc invocation
+      options[camelCase(key)] = value === undefined ? true : value === 'on' ? true : value === 'off' ? false : value;
+      break;
+  }
+}
+
+/**
+ * Build the full less.render() options object for one compilation, replicating
+ * lessc's defaults for source maps (map written next to the output file).
+ */
+export function buildRenderOptions(input: RenderOptionsInput): LessRenderOptions {
+  const options: LessRenderOptions = {
+    filename: path.resolve(input.inputFilePath)
+  };
+
+  if (input.enableJs) options.javascriptEnabled = true;
+  if (input.minified) options.compress = true;
+
+  if (input.lessArgs) {
+    for (const entry of splitTopLevelCommas(input.lessArgs)) {
+      if (entry.trim() !== '') applyLessArg(options, entry.trim());
+    }
+  }
+
+  if (input.sourceMap) {
+    const output = input.outputFilePath;
+    const inputFile = input.inputFilePath;
+    const sourceMapOptions: Record<string, unknown> = {
+      sourceMapInputFilename: inputFile,
+      sourceMapOutputFilename: path.basename(output),
+      sourceMapFullFilename: output + '.map',
+      sourceMapFilename: path.basename(output + '.map'),
+      sourceMapBasepath: path.dirname(inputFile),
+      sourceMapRootpath: path.relative(path.dirname(output + '.map'), path.dirname(inputFile))
+    };
+    options.sourceMap = sourceMapOptions;
+  }
+
+  return options;
+}
+
+interface LessApi {
+  PluginManager: new (l: unknown) => {
+    Loader: {
+      loadPlugin: (
+        name: string,
+        basePath: string,
+        context: unknown,
+        environment: unknown,
+        fileManager: unknown
+      ) => Promise<{ contents: string; filename: string }>;
+    };
+  };
+  FileManager: new () => unknown;
+  environment: unknown;
+}
+
+/**
+ * Load plugins by name the way lessc does: resolve each through the plugin
+ * manager's loader (which tries the name as given, then with the conventional
+ * less-plugin- prefix) and return plugin file descriptors for options.plugins.
+ */
+export async function loadPlugins(pluginList: string, less: LessApi, renderOptions: LessRenderOptions): Promise<unknown[]> {
+  const pluginManager = new less.PluginManager(less);
+  const fileManager = new less.FileManager();
+  const plugins: unknown[] = [];
+  for (const rawName of pluginList.split(',')) {
+    const splitup = rawName.match(/^([^=]+)(=(.*))?/);
+    if (!splitup) continue;
+    const name = splitup[1].trim();
+    const pluginOptions = splitup[3];
+    if (name === '') continue;
+    let data: { contents: string; filename: string };
+    try {
+      data = await pluginManager.Loader.loadPlugin(name, process.cwd(), { ...renderOptions }, less.environment, fileManager);
+    } catch {
+      throw new Error('Unable to load plugin ' + name + ' please make sure that it is installed under or at the same level as less');
+    }
+    plugins.push({ fileContent: data.contents, filename: data.filename, options: pluginOptions });
+  }
+  return plugins;
+}

--- a/src/lib/lessOptions.ts
+++ b/src/lib/lessOptions.ts
@@ -24,7 +24,29 @@ export function splitTopLevelCommas(value: string): string[] {
   const parts: string[] = [];
   let depth = 0;
   let current = '';
+  let quote: string | undefined;
+  let escaped = false;
   for (const ch of value) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === '\\') {
+      current += ch;
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = undefined;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      current += ch;
+      continue;
+    }
     if (ch === '(') depth++;
     else if (ch === ')' && depth > 0) depth--;
     if (ch === ',' && depth === 0) {
@@ -174,6 +196,23 @@ export function buildRenderOptions(input: RenderOptionsInput): LessRenderOptions
       sourceMapBasepath: path.dirname(inputFile),
       sourceMapRootpath: path.relative(path.dirname(output + '.map'), path.dirname(inputFile))
     };
+
+    // lessc routes source-map-* CLI arguments into the nested sourceMap
+    // options object. Move any corresponding values parsed from lessArgs out
+    // of the top-level render options so Less applies them to the map.
+    const sourceMapArgNames: Record<string, string> = {
+      sourceMapRootpath: 'sourceMapRootpath',
+      sourceMapBasepath: 'sourceMapBasepath',
+      sourceMapUrl: 'sourceMapURL',
+      sourceMapIncludeSource: 'outputSourceFiles',
+      sourceMapInline: 'sourceMapFileInline'
+    };
+    for (const [optionName, sourceMapName] of Object.entries(sourceMapArgNames)) {
+      if (optionName in options) {
+        sourceMapOptions[sourceMapName] = options[optionName];
+        delete options[optionName];
+      }
+    }
     options.sourceMap = sourceMapOptions;
   }
 
@@ -205,7 +244,7 @@ export async function loadPlugins(pluginList: string, less: LessApi, renderOptio
   const pluginManager = new less.PluginManager(less);
   const fileManager = new less.FileManager();
   const plugins: unknown[] = [];
-  for (const rawName of pluginList.split(',')) {
+  for (const rawName of splitTopLevelCommas(pluginList)) {
     const splitup = rawName.match(/^([^=]+)(=(.*))?/);
     if (!splitup) continue;
     const name = splitup[1].trim();

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -1,7 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { exec } from 'child_process';
 import fileSearch = require('./filesearch');
+import lessOptions = require('./lessOptions');
+
+// The less package ships no type definitions
+const less = require('less');
 
 interface WalkOptions {
   ignoreDotFiles?: boolean;
@@ -22,8 +25,8 @@ interface InitCallback {
 }
 
 interface CompileResult {
-  command: string;
   outputFilePath: string;
+  options: lessOptions.LessRenderOptions;
 }
 
 interface LessWatchCompilerConfig {
@@ -138,34 +141,66 @@ const lessWatchCompilerUtilsModule = {
     );
   },
 
-  getLessArgs(args: string): string {
-    const arr = args.split(',');
-    return ' --' + arr.join(' --');
-  },
-
   compileCSS(file: string, test?: boolean): CompileResult | undefined {
     const outputFilePath = this.resolveOutputPath(file);
 
     // Skip compiling hidden files unless includeHidden flag is enabled
     if (fileSearch.isHiddenFile(file) && !lessWatchCompilerUtilsModule.config.includeHidden) return;
 
-    const enableJsFlag = lessWatchCompilerUtilsModule.config.enableJs ? ' --js' : '';
-    const minifiedFlag = lessWatchCompilerUtilsModule.config.minified ? ' -x' : '';
-    const sourceMap = lessWatchCompilerUtilsModule.config.sourceMap ? ' --source-map' : '';
-    const lessArgs = lessWatchCompilerUtilsModule.config.lessArgs ? this.getLessArgs(lessWatchCompilerUtilsModule.config.lessArgs) : '';
-    const plugins = lessWatchCompilerUtilsModule.config.plugins ? ' --' + lessWatchCompilerUtilsModule.config.plugins.split(',').join(' --') : '';
-    const command = 'lessc' + lessArgs + sourceMap + enableJsFlag + minifiedFlag + plugins + ' ' + JSON.stringify(file) + ' ' + outputFilePath;
+    const outPath: string = JSON.parse(outputFilePath);
+    const options = lessOptions.buildRenderOptions({
+      inputFilePath: file,
+      outputFilePath: outPath,
+      enableJs: lessWatchCompilerUtilsModule.config.enableJs,
+      minified: lessWatchCompilerUtilsModule.config.minified,
+      sourceMap: lessWatchCompilerUtilsModule.config.sourceMap,
+      lessArgs: lessWatchCompilerUtilsModule.config.lessArgs
+    });
 
-    if (!test)
-      exec(command, (error, stdout) => {
-        if (error !== null) {
-          console.log(error);
+    if (!test) {
+      lessWatchCompilerUtilsModule
+        .renderLess(file, outPath, options)
+        .catch((error: Error & { line?: number; column?: number; filename?: string; extract?: string[] }) => {
+          console.log(lessWatchCompilerUtilsModule.formatLessError(error));
           if (lessWatchCompilerUtilsModule.config.runOnce) process.exit(1);
-        }
-        if (stdout) console.error(stdout);
-      });
+        });
+    }
 
-    return { command, outputFilePath };
+    return { outputFilePath, options };
+  },
+
+  async renderLess(file: string, outPath: string, options: lessOptions.LessRenderOptions): Promise<void> {
+    const renderOptions = { ...options };
+    if (lessWatchCompilerUtilsModule.config.plugins) {
+      renderOptions.plugins = await lessOptions.loadPlugins(lessWatchCompilerUtilsModule.config.plugins, less, renderOptions);
+    }
+    const input = await fs.promises.readFile(file, 'utf8');
+    const result = await less.render(input, renderOptions);
+    await fs.promises.mkdir(path.dirname(path.resolve(outPath)), { recursive: true });
+    await fs.promises.writeFile(outPath, result.css, 'utf8');
+    if (result.map) {
+      await fs.promises.writeFile(outPath + '.map', result.map, 'utf8');
+    }
+  },
+
+  formatLessError(error: Error & { line?: number; column?: number; filename?: string; extract?: string[]; type?: string }): string {
+    if (error.line === undefined && error.filename === undefined) return String(error.stack || error.message || error);
+    const kind = error.type ? error.type + 'Error' : 'Error';
+    let message = kind + ': ' + error.message;
+    if (error.filename) {
+      message += ' in ' + error.filename;
+      if (error.line !== undefined) message += ' on line ' + error.line + ', column ' + error.column + ':';
+    }
+    if (error.extract) {
+      const firstLine = error.line !== undefined ? error.line - 1 : 0;
+      message +=
+        '\n' +
+        error.extract
+          .filter((line: string) => line !== undefined)
+          .map((line: string, index: number) => firstLine + index + ' ' + line)
+          .join('\n');
+    }
+    return message;
   },
 
   resolveOutputPath(filePath: string): string {

--- a/test/characterization.js
+++ b/test/characterization.js
@@ -75,6 +75,24 @@ describe('Characterization: golden-file output parity', function () {
     });
   });
 
+  describe('--plugins parameter', function () {
+    it('loads a less plugin by its short name and applies it (byte-identical to golden)', () => {
+      resetOutDir();
+      cli('--run-once', '--plugins', 'clean-css', 'test/examples/with-plugin/less', 'test/css');
+      const produced = fs.readFileSync(path.join(outDir, 'with-plugin.css'));
+      const golden = fs.readFileSync(path.join(cwd, 'test', 'examples', 'with-plugin', 'css', 'with-plugin.css'));
+      assert.ok(produced.equals(golden));
+      resetOutDir();
+    });
+
+    it('exits non-zero under --run-once when a plugin cannot be loaded', () => {
+      assert.throws(
+        () => execSync(`node ${cliPath} --run-once --plugins no-such-plugin test/examples/with-plugin/less test/css`, { stdio: 'pipe' }),
+        (err) => err.status !== 0
+      );
+    });
+  });
+
   describe('config auto-discovery from cwd (issue #128)', function () {
     it('loads less-watch-compiler.config.json from the working directory when no arguments are given', () => {
       resetOutDir();

--- a/test/examples/with-plugin/css/with-plugin.css
+++ b/test/examples/with-plugin/css/with-plugin.css
@@ -1,0 +1,1 @@
+.plugin-test{color:#abc;margin:0}

--- a/test/examples/with-plugin/less/with-plugin.less
+++ b/test/examples/with-plugin/less/with-plugin.less
@@ -1,0 +1,4 @@
+.plugin-test {
+  color: #aabbcc;
+  margin: 0px;
+}

--- a/test/lessOptions.js
+++ b/test/lessOptions.js
@@ -11,7 +11,10 @@ describe('lessOptions Module', function () {
       assert.deepStrictEqual(lessOptions.splitTopLevelCommas('c=rgba(1, 2, 3, 0.5),d=4'), ['c=rgba(1, 2, 3, 0.5)', 'd=4']);
     });
     it('keeps commas inside quoted values intact', function () {
-      assert.deepStrictEqual(lessOptions.splitTopLevelCommas("modify-var='font-stack=Arial, sans-serif',compress"), ["modify-var='font-stack=Arial, sans-serif'", 'compress']);
+      assert.deepStrictEqual(lessOptions.splitTopLevelCommas("modify-var='font-stack=Arial, sans-serif',compress"), [
+        "modify-var='font-stack=Arial, sans-serif'",
+        'compress'
+      ]);
     });
     it('keeps commas inside plugin option payloads intact', function () {
       assert.deepStrictEqual(lessOptions.splitTopLevelCommas("my-plugin='a,b',other-plugin"), ["my-plugin='a,b'", 'other-plugin']);

--- a/test/lessOptions.js
+++ b/test/lessOptions.js
@@ -10,6 +10,13 @@ describe('lessOptions Module', function () {
     it('keeps commas inside parentheses intact', function () {
       assert.deepStrictEqual(lessOptions.splitTopLevelCommas('c=rgba(1, 2, 3, 0.5),d=4'), ['c=rgba(1, 2, 3, 0.5)', 'd=4']);
     });
+    it('keeps commas inside quoted values intact', function () {
+      assert.deepStrictEqual(lessOptions.splitTopLevelCommas("modify-var='font-stack=Arial, sans-serif',compress"), ["modify-var='font-stack=Arial, sans-serif'", 'compress']);
+    });
+    it('keeps commas inside plugin option payloads intact', function () {
+      assert.deepStrictEqual(lessOptions.splitTopLevelCommas("my-plugin='a,b',other-plugin"), ["my-plugin='a,b'", 'other-plugin']);
+      assert.deepStrictEqual(lessOptions.splitTopLevelCommas('my-plugin=(a,b),other-plugin'), ['my-plugin=(a,b)', 'other-plugin']);
+    });
   });
 
   describe('buildRenderOptions()', function () {
@@ -36,6 +43,20 @@ describe('lessOptions Module', function () {
         lessArgs: 'global-var=brand=#336699'
       });
       assert.deepStrictEqual(options.globalVars, { brand: '#336699' });
+    });
+    it('routes source-map arguments into the sourceMap options object', function () {
+      const options = lessOptions.buildRenderOptions({
+        inputFilePath: 'in.less',
+        outputFilePath: 'out.css',
+        sourceMap: true,
+        lessArgs: 'source-map-rootpath=/static/,source-map-basepath=/src/,source-map-url=/maps/out.css.map,source-map-include-source,source-map-inline'
+      });
+      assert.equal(options.sourceMap.sourceMapRootpath, '/static/');
+      assert.equal(options.sourceMap.sourceMapBasepath, '/src/');
+      assert.equal(options.sourceMap.sourceMapURL, '/maps/out.css.map');
+      assert.equal(options.sourceMap.outputSourceFiles, true);
+      assert.equal(options.sourceMap.sourceMapFileInline, true);
+      assert.equal(options.sourceMapRootpath, undefined);
     });
   });
 

--- a/test/lessOptions.js
+++ b/test/lessOptions.js
@@ -1,0 +1,47 @@
+const assert = require('assert'),
+  lessOptions = require('../dist/lib/lessOptions.js'),
+  less = require('less');
+
+describe('lessOptions Module', function () {
+  describe('splitTopLevelCommas()', function () {
+    it('splits a plain comma list', function () {
+      assert.deepStrictEqual(lessOptions.splitTopLevelCommas('a=1,b=2'), ['a=1', 'b=2']);
+    });
+    it('keeps commas inside parentheses intact', function () {
+      assert.deepStrictEqual(lessOptions.splitTopLevelCommas('c=rgba(1, 2, 3, 0.5),d=4'), ['c=rgba(1, 2, 3, 0.5)', 'd=4']);
+    });
+  });
+
+  describe('buildRenderOptions()', function () {
+    it('coerces unknown on/off values and passes unknown keys through camelCased', function () {
+      const options = lessOptions.buildRenderOptions({
+        inputFilePath: 'in.less',
+        outputFilePath: 'out.css',
+        lessArgs: 'some-future-flag=on'
+      });
+      assert.equal(options.someFutureFlag, true);
+    });
+    it('treats a bare key as a boolean flag', function () {
+      const options = lessOptions.buildRenderOptions({
+        inputFilePath: 'in.less',
+        outputFilePath: 'out.css',
+        lessArgs: 'strict-imports'
+      });
+      assert.equal(options.strictImports, true);
+    });
+    it('maps global-var into a globalVars object', function () {
+      const options = lessOptions.buildRenderOptions({
+        inputFilePath: 'in.less',
+        outputFilePath: 'out.css',
+        lessArgs: 'global-var=brand=#336699'
+      });
+      assert.deepStrictEqual(options.globalVars, { brand: '#336699' });
+    });
+  });
+
+  describe('loadPlugins()', function () {
+    it('rejects with a descriptive error for a plugin that cannot be resolved', async function () {
+      await assert.rejects(() => lessOptions.loadPlugins('this-plugin-does-not-exist', less, {}), /Unable to load plugin this-plugin-does-not-exist/);
+    });
+  });
+});

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -75,75 +75,81 @@ describe('lessWatchCompilerUtils Module API', function () {
       it('compileCSS() function should be there', function () {
         assert.equal('function', typeof lessWatchCompilerUtils.compileCSS);
       });
-      it('should run the correct command with minified flag', function () {
+      it('should map the minified flag to compress and a .min.css output', function () {
         lessWatchCompilerUtils.config = {
           outputFolder: 'testFolder',
           minified: true
         };
-        assert.equal('lessc -x "test.less" "testFolder/test.min.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
+        const result = lessWatchCompilerUtils.compileCSS('test.less', true);
+        assert.equal(result.outputFilePath, '"testFolder/test.min.css"');
+        assert.equal(result.options.compress, true);
       });
-      it('should run the correct command with enableJs flag', function () {
+      it('should map the enableJs flag to javascriptEnabled', function () {
         lessWatchCompilerUtils.config = {
           outputFolder: 'testFolder',
           enableJs: true
         };
-        assert.equal('lessc --js "test.less" "testFolder/test.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
+        const result = lessWatchCompilerUtils.compileCSS('test.less', true);
+        assert.equal(result.outputFilePath, '"testFolder/test.css"');
+        assert.equal(result.options.javascriptEnabled, true);
       });
-      it('should run the correct command with sourceMap flag', function () {
+      it('should map the sourceMap flag to lessc-compatible source map options', function () {
         lessWatchCompilerUtils.config = {
           outputFolder: 'testFolder',
           sourceMap: true
         };
-        assert.equal('lessc --source-map "test.less" "testFolder/test.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
+        const result = lessWatchCompilerUtils.compileCSS('test.less', true);
+        assert.deepStrictEqual(result.options.sourceMap, {
+          sourceMapInputFilename: 'test.less',
+          sourceMapOutputFilename: 'test.css',
+          sourceMapFullFilename: 'testFolder/test.css.map',
+          sourceMapFilename: 'test.css.map',
+          sourceMapBasepath: '.',
+          sourceMapRootpath: '..'
+        });
       });
-      it('should run the correct command with 1 plugin', function () {
+      it('should resolve the input filename to an absolute path for import resolution', function () {
         lessWatchCompilerUtils.config = {
-          outputFolder: 'testFolder',
-          plugins: 'plugin1'
+          outputFolder: 'testFolder'
         };
-        assert.equal('lessc --plugin1 "test.less" "testFolder/test.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
-      });
-      it('should run the correct command with 2 plugins', function () {
-        lessWatchCompilerUtils.config = {
-          outputFolder: 'testFolder',
-          plugins: 'plugin1,plugin2'
-        };
-        assert.equal('lessc --plugin1 --plugin2 "test.less" "testFolder/test.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
+        const result = lessWatchCompilerUtils.compileCSS('test.less', true);
+        assert.equal(result.options.filename, path.resolve('test.less'));
       });
 
-      it('should run the correct command with minified flag', function () {
-        lessWatchCompilerUtils.config = {
-          outputFolder: 'testFolder',
-          minified: true
-        };
-        assert.equal('lessc -x "test.less" "testFolder/test.min.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
-      });
-
-      it('should run the correct command with math LESS flag', function () {
+      it('should map the math LESS flag', function () {
         lessWatchCompilerUtils.config = {
           outputFolder: 'testFolder',
           lessArgs: 'math=strict'
         };
-        assert.equal('lessc --math=strict "test.less" "testFolder/test.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
+        assert.equal(lessWatchCompilerUtils.compileCSS('test.less', true).options.math, 'strict');
       });
 
-      it('should run the correct command with strict-unit LESS flag', function () {
+      it('should map the strict-units LESS flag to a boolean', function () {
         lessWatchCompilerUtils.config = {
           outputFolder: 'testFolder',
           lessArgs: 'strict-units=on'
         };
-        assert.equal('lessc --strict-units=on "test.less" "testFolder/test.css"', lessWatchCompilerUtils.compileCSS('test.less', true).command);
+        assert.equal(lessWatchCompilerUtils.compileCSS('test.less', true).options.strictUnits, true);
       });
 
-      it('should run the correct command with math, strict-unit, include-path LESS flags', function () {
+      it('should map math, strict-units, and include-path together', function () {
         lessWatchCompilerUtils.config = {
           outputFolder: 'testFolder',
           lessArgs: 'math=strict,strict-units=on,include-path=./dir1;./dir2'
         };
-        assert.equal(
-          'lessc --math=strict --strict-units=on --include-path=./dir1;./dir2 "test.less" "testFolder/test.css"',
-          lessWatchCompilerUtils.compileCSS('test.less', true).command
-        );
+        const options = lessWatchCompilerUtils.compileCSS('test.less', true).options;
+        assert.equal(options.math, 'strict');
+        assert.equal(options.strictUnits, true);
+        assert.deepStrictEqual(options.paths, ['./dir1', './dir2']);
+      });
+
+      it('should keep commas inside parentheses in modify-var values (issue #103)', function () {
+        lessWatchCompilerUtils.config = {
+          outputFolder: 'testFolder',
+          lessArgs: "modify-var='text-color=rgba(23, 34, 45, 0.5)'"
+        };
+        const options = lessWatchCompilerUtils.compileCSS('test.less', true).options;
+        assert.deepStrictEqual(options.modifyVars, { 'text-color': 'rgba(23, 34, 45, 0.5)' });
       });
 
       it('should not compile hidden files by default', function () {
@@ -158,7 +164,7 @@ describe('lessWatchCompilerUtils Module API', function () {
           outputFolder: 'testFolder',
           includeHidden: true
         };
-        assert.equal('lessc "_test.less" "testFolder/_test.css"', lessWatchCompilerUtils.compileCSS('_test.less', true).command);
+        assert.equal(lessWatchCompilerUtils.compileCSS('_test.less', true).outputFilePath, '"testFolder/_test.css"');
       });
     });
     describe('resolveOutputPath()', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,6 +536,13 @@ chokidar@^4.0.1:
   dependencies:
     readdirp "^4.0.1"
 
+clean-css@5.3.3:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-5.3.3.tgz#b330653cd3bd6b75009cc25c714cae7b93351ccd"
+  integrity sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==
+  dependencies:
+    source-map "~0.6.0"
+
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -1329,6 +1336,13 @@ keyv@^4.5.4:
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+less-plugin-clean-css@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/less-plugin-clean-css/-/less-plugin-clean-css-1.6.0.tgz#befc051436759c1bb1f13d026e39f735f7ba0185"
+  integrity sha512-jwXX6WlXT57OVCXa5oBJBaJq1b4s1BOKeEEoAL2UTeEitogQWfTcBbLT/vow9pl0N0MXV8Mb4KyhTGG0YbEKyQ==
+  dependencies:
+    clean-css "5.3.3"
 
 less@^4.0.0:
   version "4.4.2"


### PR DESCRIPTION
## **User description**
Fixes #103

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:

- **Replace the `exec('lessc ...')` shell-out in `compileCSS` with `less.render()`** from the already-bundled `less` dependency. Compilation now happens in-process.
- New `src/lib/lessOptions.ts` translates config and `--less-args` entries into render options following lessc's own argument table (`math`, `strict-units`, `include-path`, `global-var`/`modify-var`, `rewrite-urls`, the full source-map filename/rootpath recipe, etc.), and loads plugins through `less.PluginManager` exactly as lessc does.
- **Verified byte-identical output** against the golden characterization fixtures from the previous PR in this stack: recursive trees, minified, source maps (css + `.map`), enable-js, less-args, main-file, hidden files, and plugins (new `less-plugin-clean-css` golden + integration test). Also verified end-to-end with no `lessc` binary reachable on PATH.

Why:

- no more `npm install -g less` prerequisite (README updated)
- no shell command string-building — removes the injection surface and cross-platform quoting issues
- structured compile errors with file/line/column formatting
- `--less-args` values may now contain commas inside parentheses, e.g. `modify-var='c=rgba(1, 2, 3, 0.5)'` (fixes #103)
- no process spawn per compiled file

Part 2 of a 3-PR stack: hardening (#199) → **in-process compile (this PR)** → programmatic API (#198). Merge #199 first; this PR's diff reduces to a single commit once its base is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
Compile LESS without needing a separate global `lessc` install

### What Changed
- LESS files are now compiled inside the app instead of by spawning a shell command
- Plugin loading now works with named LESS plugins, including `clean-css`
- `--less-args` now keeps values with commas inside parentheses intact, so color and variable values are parsed correctly
- LESS compile errors are shown with clearer file, line, and column details
- Source maps, minified output, hidden-file handling, and plugin output are kept byte-for-byte consistent with the previous behavior

### Impact
`✅ No global LESS installation required`
`✅ Fewer plugin loading failures`
`✅ Clearer LESS compile errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
