### PR TITLE
fix(#209): watch the containing directory of an @import outside watchFolder

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -389,7 +389,8 @@ const lessWatchCompilerUtilsModule = {
       const hasExtension = path.extname(importSpec).length > 1;
       const importFile = hasExtension ? importSpec : importSpec + '.less';
       const importPath = path.normalize(path.dirname(f) + path.sep + importFile);
-      if (filelistArr.indexOf(importSpec) === -1) {
+      if (filelistArr.indexOf(importPath) === -1) {
+        filelistArr[filelistArr.length] = importPath;
         lessWatchCompilerUtilsModule.setupWatcher(importPath, files, options, watchCallback);
       }
       lessWatchCompilerUtilsModule.watchExternalImportDir(importPath, files, options, filelistArr, fileimportlistObj, watchCallback);
@@ -425,13 +426,30 @@ const lessWatchCompilerUtilsModule = {
     const importDir = path.dirname(importPath);
     if (filelistArr.indexOf(importDir) !== -1) return;
     let stat: fs.Stats;
+    let existingEntries: string[];
     try {
       stat = fs.statSync(importDir);
+      existingEntries = fs.readdirSync(importDir);
     } catch {
       // The directory doesn't exist yet; nothing to watch until it does.
       return;
     }
     files[importDir] = stat;
+    // Seed every file already in the directory into `files`, mirroring what
+    // walk() does up front for directories inside watchFolder. Without this,
+    // setupWatcher's directory branch (`if (!files[file])`) would treat each
+    // pre-existing sibling as newly added the first time anything else in
+    // the directory changes, firing a spurious watchCallback/compile for
+    // files that were never touched and aren't anyone's @import.
+    for (const entry of existingEntries) {
+      const entryPath = path.join(importDir, entry);
+      if (files[entryPath]) continue;
+      try {
+        files[entryPath] = fs.statSync(entryPath);
+      } catch {
+        // Raced with a delete between readdir and stat; nothing to seed.
+      }
+    }
     lessWatchCompilerUtilsModule.fileWatcher(importDir, files, options, filelistArr, fileimportlistObj, watchCallback);
   }
 };

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -385,10 +385,54 @@ const lessWatchCompilerUtilsModule = {
     fileimportlistObj[f] = fileSearch.findLessImportsInFile(f);
     lessWatchCompilerUtilsModule.setupWatcher(f, files, options, watchCallback);
     for (const i in fileimportlistObj[f]) {
-      if (filelistArr.indexOf(fileimportlistObj[f][i]) === -1) {
-        lessWatchCompilerUtilsModule.setupWatcher(path.normalize(path.dirname(f) + path.sep + fileimportlistObj[f][i]), files, options, watchCallback);
+      const importSpec = fileimportlistObj[f][i];
+      const hasExtension = path.extname(importSpec).length > 1;
+      const importFile = hasExtension ? importSpec : importSpec + '.less';
+      const importPath = path.normalize(path.dirname(f) + path.sep + importFile);
+      if (filelistArr.indexOf(importSpec) === -1) {
+        lessWatchCompilerUtilsModule.setupWatcher(importPath, files, options, watchCallback);
       }
+      lessWatchCompilerUtilsModule.watchExternalImportDir(importPath, files, options, filelistArr, fileimportlistObj, watchCallback);
     }
+  },
+
+  /**
+   * An @import target inside watchFolder gets directory-level recreate
+   * detection for free: walk() discovers every directory up front, and each
+   * one is handed to fileWatcher()/setupWatcher(), whose directory branch
+   * notices new files via a readdir rescan. An @import target that resolves
+   * outside watchFolder never goes through that walk, so it's watched as a
+   * lone file above -- and setupWatcher's removal branch unwatches a deleted
+   * file permanently, with nothing watching its directory to notice it come
+   * back (issue #209). Mirror the in-root behavior by explicitly watching
+   * the external target's containing directory the same way, scoped to just
+   * that one directory (not a recursive walk of the external tree).
+   */
+  watchExternalImportDir(
+    importPath: string,
+    files: FilesMap,
+    options: WalkOptions,
+    filelistArr: string[],
+    fileimportlistObj: Record<string, string[]>,
+    watchCallback: WatchCallback
+  ): void {
+    const watchFolder = lessWatchCompilerUtilsModule.config.watchFolder;
+    if (!watchFolder) return;
+    const relative = path.relative(watchFolder, importPath);
+    const isExternal = relative.startsWith('..') || path.isAbsolute(relative);
+    if (!isExternal) return;
+
+    const importDir = path.dirname(importPath);
+    if (filelistArr.indexOf(importDir) !== -1) return;
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(importDir);
+    } catch {
+      // The directory doesn't exist yet; nothing to watch until it does.
+      return;
+    }
+    files[importDir] = stat;
+    lessWatchCompilerUtilsModule.fileWatcher(importDir, files, options, filelistArr, fileimportlistObj, watchCallback);
   }
 };
 

--- a/test/characterization.js
+++ b/test/characterization.js
@@ -189,6 +189,69 @@ describe('Characterization: watch-mode startup (issue #117)', function () {
   });
 });
 
+describe('Characterization: external @import survives delete+recreate (issue #209)', function () {
+  this.timeout(20000);
+
+  function waitForContent(filePath, predicate, timeoutMs, cb) {
+    const start = Date.now();
+    (function poll() {
+      fs.readFile(filePath, 'utf8', (err, content) => {
+        if (!err && predicate(content)) return cb(null, content);
+        if (Date.now() - start > timeoutMs) return cb(new Error('timed out waiting for ' + filePath + '; last content: ' + (content || err)));
+        setTimeout(poll, 50);
+      });
+    })();
+  }
+
+  it('recompiles the importing file after an @import target outside watchFolder is deleted and recreated', (done) => {
+    const tmpDir = fs.mkdtempSync(path.join(cwd, 'test', 'tmp-external-import-'));
+    const lessDir = path.join(tmpDir, 'less');
+    const externalDir = path.join(tmpDir, 'external');
+    const liveOutDir = path.join(tmpDir, 'css');
+    fs.mkdirSync(lessDir);
+    fs.mkdirSync(externalDir);
+    fs.mkdirSync(liveOutDir);
+    const externalFile = path.join(externalDir, 'partial.less');
+    const mainFile = path.join(lessDir, 'main.less');
+    fs.writeFileSync(externalFile, '.partial { color: red; }');
+    fs.writeFileSync(mainFile, "@import '../external/partial.less';\n.main { color: blue; }");
+
+    const child = spawn('node', [cliPath, lessDir, liveOutDir], { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+
+    function cleanup() {
+      child.kill('SIGTERM');
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    const outputCss = path.join(liveOutDir, 'main.css');
+    waitForContent(
+      outputCss,
+      (c) => c.includes('red'),
+      5000,
+      (err) => {
+        if (err) {
+          cleanup();
+          return done(err);
+        }
+        fs.rmSync(externalFile);
+        setTimeout(() => {
+          fs.writeFileSync(externalFile, '.partial { color: green; }');
+          waitForContent(
+            outputCss,
+            (c) => c.includes('green'),
+            10000,
+            (err2) => {
+              cleanup();
+              if (err2) return done(err2);
+              done();
+            }
+          );
+        }, 500);
+      }
+    );
+  });
+});
+
 describe('Characterization: live watch mode (real CLI process, no --run-once)', function () {
   this.timeout(20000);
 

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -568,5 +568,77 @@ describe('lessWatchCompilerUtils Module API', function () {
         done();
       });
     });
+    describe('watchExternalImportDir() (issue #209: external @import survives delete+recreate)', function () {
+      let originalWatchFolder;
+      beforeEach(function () {
+        originalWatchFolder = lessWatchCompilerUtils.config.watchFolder;
+      });
+      afterEach(function () {
+        lessWatchCompilerUtils.config.watchFolder = originalWatchFolder;
+      });
+
+      it('watchExternalImportDir() function should be there', function () {
+        assert.equal('function', typeof lessWatchCompilerUtils.watchExternalImportDir);
+      });
+
+      it('registers a directory watch for an @import target that resolves outside watchFolder', function () {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-external-dir-'));
+        const watchFolder = path.join(tmpDir, 'less');
+        const externalDir = path.join(tmpDir, 'external');
+        fs.mkdirSync(watchFolder);
+        fs.mkdirSync(externalDir);
+        const externalFile = path.join(externalDir, 'partial.less');
+        fs.writeFileSync(externalFile, '.partial {}');
+        lessWatchCompilerUtils.config.watchFolder = watchFolder;
+
+        const files = {};
+        const filelistArr = [];
+        lessWatchCompilerUtils.watchExternalImportDir(externalFile, files, { interval: 30 }, filelistArr, {}, function () {});
+
+        try {
+          assert.ok(files[externalDir], 'the external directory must be recorded in the files map');
+          assert.ok(filelistArr.indexOf(externalDir) !== -1, 'the external directory must be added to the dedup list');
+        } finally {
+          fs.unwatchFile(externalDir);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      });
+
+      it('is a no-op for an @import target inside watchFolder (already covered by the recursive walk)', function () {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-internal-dir-'));
+        const watchFolder = path.join(tmpDir, 'less');
+        fs.mkdirSync(watchFolder);
+        const internalFile = path.join(watchFolder, 'partial.less');
+        fs.writeFileSync(internalFile, '.partial {}');
+        lessWatchCompilerUtils.config.watchFolder = watchFolder;
+
+        const files = {};
+        const filelistArr = [];
+        lessWatchCompilerUtils.watchExternalImportDir(internalFile, files, { interval: 30 }, filelistArr, {}, function () {});
+
+        assert.deepStrictEqual(files, {});
+        assert.deepStrictEqual(filelistArr, []);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      });
+
+      it('is a no-op when watchFolder is not configured', function () {
+        lessWatchCompilerUtils.config.watchFolder = undefined;
+        const files = {};
+        const filelistArr = [];
+        lessWatchCompilerUtils.watchExternalImportDir('/some/external/file.less', files, {}, filelistArr, {}, function () {});
+        assert.deepStrictEqual(files, {});
+        assert.deepStrictEqual(filelistArr, []);
+      });
+
+      it('does not throw when the external directory does not exist (nothing to watch until it does)', function () {
+        lessWatchCompilerUtils.config.watchFolder = path.join(cwd, 'test/less');
+        const files = {};
+        const filelistArr = [];
+        assert.doesNotThrow(() => {
+          lessWatchCompilerUtils.watchExternalImportDir(path.join(cwd, 'test/does-not-exist/partial.less'), files, {}, filelistArr, {}, function () {});
+        });
+        assert.deepStrictEqual(files, {});
+      });
+    });
   });
 });

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -567,6 +567,41 @@ describe('lessWatchCompilerUtils Module API', function () {
         lessWatchCompilerUtils.fileWatcher(testRelative, {}, {}, [], [], function () {});
         done();
       });
+
+      it('registers only one fs.watchFile listener for a file imported by two different files', function () {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-shared-import-'));
+        const shared = path.join(tmpDir, 'shared.less');
+        const a = path.join(tmpDir, 'a.less');
+        const b = path.join(tmpDir, 'b.less');
+        fs.writeFileSync(shared, '.shared {}');
+        fs.writeFileSync(a, "@import 'shared.less';\n.a {}");
+        fs.writeFileSync(b, "@import 'shared.less';\n.b {}");
+
+        const files = { [a]: fs.statSync(a), [b]: fs.statSync(b) };
+        const filelistArr = [];
+        const originalWatchFolder = lessWatchCompilerUtils.config.watchFolder;
+        lessWatchCompilerUtils.config.watchFolder = tmpDir;
+
+        let watchFileCalls = 0;
+        const originalWatchFile = fs.watchFile;
+        fs.watchFile = function (f, ...rest) {
+          if (f === shared) watchFileCalls++;
+          return originalWatchFile.call(fs, f, ...rest);
+        };
+
+        try {
+          lessWatchCompilerUtils.fileWatcher(a, files, { interval: 9999 }, filelistArr, {}, function () {});
+          lessWatchCompilerUtils.fileWatcher(b, files, { interval: 9999 }, filelistArr, {}, function () {});
+          assert.equal(watchFileCalls, 1, 'a file imported by two different importers must only be watched once');
+        } finally {
+          fs.watchFile = originalWatchFile;
+          lessWatchCompilerUtils.config.watchFolder = originalWatchFolder;
+          fs.unwatchFile(shared);
+          fs.unwatchFile(a);
+          fs.unwatchFile(b);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+      });
     });
     describe('watchExternalImportDir() (issue #209: external @import survives delete+recreate)', function () {
       let originalWatchFolder;
@@ -638,6 +673,33 @@ describe('lessWatchCompilerUtils Module API', function () {
           lessWatchCompilerUtils.watchExternalImportDir(path.join(cwd, 'test/does-not-exist/partial.less'), files, {}, filelistArr, {}, function () {});
         });
         assert.deepStrictEqual(files, {});
+      });
+
+      it('seeds every pre-existing sibling in the external directory into the files map', function () {
+        // Regression test: without seeding, setupWatcher's directory branch
+        // (`if (!files[file])`) would treat every pre-existing sibling as
+        // newly added on the next unrelated directory change, firing a
+        // spurious watchCallback/compile for files that were never touched
+        // and aren't anyone's @import.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-external-seed-'));
+        const externalDir = path.join(tmpDir, 'external');
+        fs.mkdirSync(externalDir);
+        const importTarget = path.join(externalDir, 'partial.less');
+        const sibling = path.join(externalDir, 'unrelated.less');
+        fs.writeFileSync(importTarget, '.partial {}');
+        fs.writeFileSync(sibling, '.unrelated {}');
+        lessWatchCompilerUtils.config.watchFolder = path.join(tmpDir, 'less');
+
+        const files = {};
+        const filelistArr = [];
+        lessWatchCompilerUtils.watchExternalImportDir(importTarget, files, { interval: 30 }, filelistArr, {}, function () {});
+
+        try {
+          assert.ok(files[sibling], 'a pre-existing sibling of the import target must be seeded, not treated as new later');
+        } finally {
+          fs.unwatchFile(externalDir);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
       });
     });
   });


### PR DESCRIPTION
## **User description**
## Summary

Fixes #209: an `@import` target that resolves **outside** `watchFolder`, once deleted, could never be picked back up if it was later recreated.

- A file inside `watchFolder` gets directory-level recreate detection for free: `walk()` discovers every directory up front and hands each one to `fileWatcher()`/`setupWatcher()`, whose directory branch notices new files via a readdir rescan.
- An external `@import` target never goes through that walk — it was only ever watched as a lone file, so once `fs.watchFile`'s removal branch unwatched it on delete (`fs.unwatchFile`), nothing was watching its directory to notice it come back.
- New `watchExternalImportDir()` closes the gap: when `fileWatcher()` resolves an `@import` to a path outside `watchFolder`, it also registers the target's containing directory using the exact same mechanism in-root directories already use — scoped to just that one directory, no recursive walk of the external tree.
- Reuses the existing shared `files`/`filelist`/`fileimportlist` state (internal bookkeeping, not part of the public API) rather than introducing a parallel tracking structure — simplest and cheapest given it's implementation-internal.

## Test plan

- [x] New end-to-end test (real CLI process, live watch mode): an `@import` target outside `watchFolder` is deleted then recreated with different content — the importing file recompiles with the new content. **Verified this actually reproduces the bug**: reverted the fix locally and confirmed the test times out (output stuck at the pre-deletion CSS); restored the fix and confirmed it passes.
- [x] New `watchExternalImportDir()` unit tests: registers a directory watch for an external target, no-ops for an in-root target, no-ops when `watchFolder` isn't configured, doesn't throw when the target directory doesn't exist yet
- [x] Full suite green: `yarn lint && yarn typecheck && yarn test` (127 passing)
- [x] Coverage above the enforced gate: 96.06%/84.19%/86.48%/96.06% vs. 93/80/85/93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
**Keep external `@import` files watched after delete and recreate**

### What Changed
- Files imported from outside `watchFolder` are now watched by their containing folder, so deleting and recreating them triggers a fresh rebuild
- Imports inside `watchFolder` keep using the existing watch behavior
- Missing external folders are ignored until they exist, so watch mode does not fail on startup
- Added tests for external imports, internal imports, missing folders, and the end-to-end delete/recreate flow

### Impact
`✅ External imports rebuild after file restore`
`✅ Fewer stuck watch sessions`
`✅ Clearer live-reload behavior for shared styles`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
