### PR TITLE
fix: create the --cache-path parent directory before writing

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -72,6 +72,7 @@ function registerExitFlush(): void {
 function flush(): void {
   if (!dirty || !loadedPath || !store) return;
   try {
+    fs.mkdirSync(path.dirname(loadedPath), { recursive: true });
     fs.writeFileSync(loadedPath, JSON.stringify(store), 'utf8');
     dirty = false;
   } catch {

--- a/test/cache.js
+++ b/test/cache.js
@@ -99,6 +99,14 @@ describe('cache Module', function () {
     assert.equal(cache.isUpToDate(cachePath, fp, lessFile, outFile, [mapFile]), false, 'a missing expected file must force a miss');
   });
 
+  it('creates the cache-path parent directory if it does not exist yet, instead of silently dropping the write', function () {
+    const nestedCachePath = path.join(tmpDir, 'does', 'not', 'exist', 'cache.json');
+    const cache = freshCache();
+    cache.record(nestedCachePath, fp, lessFile, outFile);
+    cache.flush();
+    assert.ok(fs.existsSync(nestedCachePath), 'flush() must create any missing parent directories');
+  });
+
   it('invalidates the whole cache when the option fingerprint changes', function () {
     const cache = freshCache();
     cache.record(cachePath, fp, lessFile, outFile);


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #210 (already merged), fixing a review finding that came in after merge.

- `cache.ts`'s `flush()` calls `fs.writeFileSync(loadedPath, ...)` without ensuring the parent directory exists. If `--cache-path` points into a directory that doesn't exist yet (a very plausible CI shape — e.g. a fresh cache-restore location), `writeFileSync` throws `ENOENT`, which the surrounding try/catch silently swallows. The result: `--cache` runs without error, but the cache file is never actually written, so every run recompiles from scratch with no indication anything is wrong.
- Fix: `fs.mkdirSync(path.dirname(loadedPath), { recursive: true })` before the write.

## Test plan

- [x] Confirmed the bug via repro before fixing (cache file silently absent after `record()` + `flush()` into a non-existent directory)
- [x] Added a regression test (`test/cache.js`)
- [x] Full suite green: `yarn lint && yarn typecheck && yarn test` (144 passing)
- [x] Coverage above the enforced gate: 96.23%/85.63%/90%/96.23% vs. 93/80/85/93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
Make cache writes work when the target folder does not exist

### What Changed
- Cache files are now written after creating any missing parent folders, so `--cache-path` works even in a new or restored directory
- If the cache write fails, compilation still continues, but the cache is no longer silently skipped when the folder is missing
- Added a regression test to confirm the cache file is created in a nested path with no existing parents

### Impact
`✅ Fewer cold builds from missing cache files`
`✅ Reliable cache writes in fresh CI directories`
`✅ Fewer repeated recompiles after cache restore`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
