### PR TITLE
fix(#197): debounce a transient missing-file poll before unwatching

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -359,15 +359,27 @@ const lessWatchCompilerUtilsModule = {
         // unwatched, so fs.watchFile's own next poll independently detects
         // the reappearance (a new mtime) as a normal change below and
         // triggers a recompile through the existing path.
+        //
+        // Snapshot the last-confirmed-present stat (undefined if the path
+        // was never confirmed) so a stale timer can tell it's stale: if a
+        // recreate is observed before this timer fires, files[f] is
+        // reassigned to a new object below, and this timer's snapshot no
+        // longer matches. Without this, a second, unrelated missing poll
+        // (e.g. rapid consecutive non-atomic saves) landing just as this
+        // timer checks could be mistaken for confirmation of the original
+        // poll's removal and unwatch a file that's still actively in use.
+        const lastKnownStat = files[f];
         const debounceMs = Math.max(options.interval !== undefined ? options.interval : 0, 300);
         setTimeout(() => {
+          if (files[f] !== lastKnownStat) return;
           fs.access(f, fs.constants.F_OK, (accessErr) => {
             if (!accessErr) return;
+            if (files[f] !== lastKnownStat) return;
             // A path that never existed also fires this callback once, on
             // its very first poll (e.g. a broken/not-yet-created @import
             // target watched preemptively) -- not a removal, and there's
             // nothing to notify since files[f] was never confirmed present.
-            const existed = !!files[f];
+            const existed = !!lastKnownStat;
             delete files[f];
             fs.unwatchFile(f);
             if (existed && !(options.ignoreDotFiles && path.basename(f)[0] === '.') && !(options.filter && options.filter(f))) {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -343,25 +343,41 @@ const lessWatchCompilerUtilsModule = {
     if (options.interval !== undefined) watchOptions.interval = options.interval;
     fs.watchFile(f, watchOptions, (c: fs.Stats, p: fs.Stats) => {
       if (files[f] && !files[f].isDirectory() && c.nlink !== 0 && files[f].mtime.getTime() === c.mtime.getTime()) return;
-      files[f] = c as fs.Stats;
       if ((c as fs.Stats).nlink === 0) {
-        // The file was removed. fs.access below would always fail on a
-        // removed path, which used to swallow the notification entirely
-        // (it only logged "Does not exist" and never called watchCallback,
-        // so onRemove listeners could never fire). Notify directly instead.
+        // The file (or directory) appears gone. Some editors save by
+        // deleting the original path and recreating it a moment later
+        // (rather than an atomic rename), so a single missing poll doesn't
+        // necessarily mean a real removal (issue #197: treating it as one
+        // used to unwatch the file permanently, silently, right after such
+        // a save). fs.watchFile only invokes this callback once on the
+        // exists->gone transition -- it will not fire again while the path
+        // stays missing -- so a second poll can't be used to confirm this;
+        // recheck for real with our own fs.access after one poll interval
+        // instead of acting immediately.
         //
-        // Guard on (p as fs.Stats).nlink !== 0: fs.watchFile fires once with
-        // curr.nlink === 0 AND prev.nlink === 0 the first time it polls a
-        // path that never existed (e.g. a broken/not-yet-created @import
-        // target watched preemptively) -- that's not a removal and must not
-        // be reported as one.
-        if ((p as fs.Stats).nlink !== 0 && !(options.ignoreDotFiles && path.basename(f)[0] === '.') && !(options.filter && options.filter(f))) {
-          watchCallback(f, c as fs.Stats, p as fs.Stats, fileimportlist);
-        }
-        delete files[f];
-        fs.unwatchFile(f);
+        // If the recheck finds the path back, do nothing here: we never
+        // unwatched, so fs.watchFile's own next poll independently detects
+        // the reappearance (a new mtime) as a normal change below and
+        // triggers a recompile through the existing path.
+        const debounceMs = Math.max(options.interval !== undefined ? options.interval : 0, 300);
+        setTimeout(() => {
+          fs.access(f, fs.constants.F_OK, (accessErr) => {
+            if (!accessErr) return;
+            // A path that never existed also fires this callback once, on
+            // its very first poll (e.g. a broken/not-yet-created @import
+            // target watched preemptively) -- not a removal, and there's
+            // nothing to notify since files[f] was never confirmed present.
+            const existed = !!files[f];
+            delete files[f];
+            fs.unwatchFile(f);
+            if (existed && !(options.ignoreDotFiles && path.basename(f)[0] === '.') && !(options.filter && options.filter(f))) {
+              watchCallback(f, c as fs.Stats, p as fs.Stats, fileimportlist);
+            }
+          });
+        }, debounceMs);
         return;
       }
+      files[f] = c as fs.Stats;
       if (!files[f].isDirectory()) {
         if (options.ignoreDotFiles && path.basename(f)[0] === '.') return;
         if (options.filter && options.filter(f)) return;

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -285,6 +285,61 @@ describe('lessWatchCompilerUtils Module API', function () {
         }, 100);
       });
 
+      it('ignores a stale removal-debounce timer superseded by a later delete+recreate (issue #197 follow-up)', function (done) {
+        // A first missing poll schedules a recheck timer. If, before that
+        // timer fires, the file is recreated and then deleted *again*, the
+        // first timer's fs.access check can land exactly inside that SECOND
+        // gap and mistake it for confirmation of the FIRST poll's removal --
+        // unwatching a file that's still actively being saved. The timer
+        // must recognize it's been superseded and do nothing.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-stale-timer-'));
+        const file = path.join(tmpDir, 'main.less');
+        fs.writeFileSync(file, '.a { color: red; }');
+        const files = { [file]: fs.statSync(file) };
+        const events = [];
+
+        function cleanup() {
+          fs.unwatchFile(file);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        lessWatchCompilerUtils.setupWatcher(file, files, { interval: 30 }, (f, curr) => {
+          events.push(curr.nlink === 0 ? 'removed' : 'changed');
+        });
+
+        // t=100: delete #1 (schedules a recheck ~300ms later, at ~t=400+).
+        setTimeout(() => {
+          fs.unlinkSync(file);
+          setTimeout(() => {
+            // t=150: recreate -- delete #1's timer is now stale.
+            fs.writeFileSync(file, '.a { color: green; }');
+            setTimeout(() => {
+              // t=350: delete #2, shortly before delete #1's ~400ms recheck fires.
+              fs.unlinkSync(file);
+              setTimeout(() => {
+                // t=450: recreate again -- this should end up alive and watched.
+                fs.writeFileSync(file, '.a { color: blue; }');
+                setTimeout(() => {
+                  // A later, unrelated real edit must still be detected.
+                  fs.writeFileSync(file, '.a { color: purple; }');
+                  setTimeout(() => {
+                    try {
+                      assert.ok(!events.includes('removed'), 'no removal event should fire across this sequence; got: ' + JSON.stringify(events));
+                      assert.ok(events.includes('changed'), 'at least the later edits must still be detected; got: ' + JSON.stringify(events));
+                      cleanup();
+                      done();
+                    } catch (e) {
+                      cleanup();
+                      done(e);
+                    }
+                  }, 500);
+                }, 750);
+              }, 100);
+            }, 200);
+          }, 50);
+        }, 100);
+      });
+
       it('does not fire the watch callback for a path that never existed (e.g. a broken @import target)', function (done) {
         // setupWatcher() is called directly by fileWatcher() for @import
         // targets, which may not resolve to a real file. fs.watchFile fires

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -237,6 +237,54 @@ describe('lessWatchCompilerUtils Module API', function () {
         }, 200);
       });
 
+      it('survives a transient delete+recreate (e.g. a non-atomic editor save) without permanently unwatching (issue #197)', function (done) {
+        // fs.watchFile only fires once on the exists->gone transition and
+        // never again while the path stays missing, so a single missing
+        // poll used to be treated as a confirmed removal and unwatched
+        // immediately -- permanently orphaning the watcher if that poll
+        // happened to land inside an editor's delete-then-recreate save
+        // window instead of a real deletion.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-transient-'));
+        const file = path.join(tmpDir, 'main.less');
+        fs.writeFileSync(file, '.a { color: red; }');
+        const files = { [file]: fs.statSync(file) };
+        const events = [];
+
+        function cleanup() {
+          fs.unwatchFile(file);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        lessWatchCompilerUtils.setupWatcher(file, files, { interval: 30 }, (f, curr) => {
+          events.push(curr.nlink === 0 ? 'removed' : 'changed');
+        });
+
+        setTimeout(() => {
+          fs.unlinkSync(file);
+          // Recreate well within the debounce window (>= 300ms), simulating
+          // a delete-then-recreate save landing inside a single poll gap.
+          setTimeout(() => {
+            fs.writeFileSync(file, '.a { color: green; }');
+            setTimeout(() => {
+              // A separate, later real edit must still be detected --
+              // proving the watcher wasn't torn down by the blip.
+              fs.writeFileSync(file, '.a { color: blue; }');
+              setTimeout(() => {
+                try {
+                  assert.ok(!events.includes('removed'), 'a transient blip must not fire a removal event; got: ' + JSON.stringify(events));
+                  assert.ok(events.includes('changed'), 'the recreation and/or later edit must still be detected; got: ' + JSON.stringify(events));
+                  cleanup();
+                  done();
+                } catch (e) {
+                  cleanup();
+                  done(e);
+                }
+              }, 300);
+            }, 300);
+          }, 100);
+        }, 100);
+      });
+
       it('does not fire the watch callback for a path that never existed (e.g. a broken @import target)', function (done) {
         // setupWatcher() is called directly by fileWatcher() for @import
         // targets, which may not resolve to a real file. fs.watchFile fires


### PR DESCRIPTION
## Summary

Fixes #197. Supersedes #205 (see comment there for why).

`setupWatcher()` unwatched a file on the very first `fs.watchFile` poll that saw it gone (`nlink === 0`), on the assumption that meant a real deletion. Some editors/tools save by deleting the original path and recreating it a moment later, rather than an atomic rename — if a poll landed inside that gap, the file was silently unwatched **forever**: every future edit to it went undetected, with no error. That matches #197's "stops working" report.

Reproduced directly against real `fs.watchFile` timing (not synthetic stat objects) before writing any fix:
```
[t+100] unlinking (leaving it gone for 100ms, longer than the poll interval)
[t+200] recreating with new content
[t+700] doing a THIRD, separate real edit
=== events ===
watchCallback fired: nlink=0 at ...   <- only ONE event: the file, and the later
                                          real edit, are never seen again
```

### Why not just "wait for the next poll to confirm" (PR #205's approach)?

I initially tried that too — it's the natural-looking fix. It doesn't work: **`fs.watchFile` only invokes its callback once on the exists→gone transition, and never again while the path stays missing** (verified this separately with a raw `fs.watchFile` probe — after unlinking, exactly one callback fires, then nothing for the next second even though the file stays gone). So there's no second poll event to confirm against for a genuine, permanent removal — that approach either never confirms real removals, or (as in #205's diff) only appears to work because its unit test drives the callback directly with hand-built `curr`/`prev` objects rather than exercising real polling.

### The actual fix

On a missing poll, don't act immediately — schedule a plain `fs.access()` recheck after a short delay (`max(pollInterval, 300ms)`) instead:
- Still missing at recheck time → confirmed real removal → unwatch + notify (existing `onRemove` behavior, just no longer instant).
- Back by recheck time → do nothing. We never unwatched, so `fs.watchFile`'s own next poll independently detects the reappearance as a normal change and triggers a recompile through the existing path — verified this happens correctly.

## Test plan

- [x] New regression test simulating the exact race (delete, recreate within the debounce window, then a separate later edit) — confirmed it fails without the fix (`git stash` the source change, rerun: fails with `a transient blip must not fire a removal event`) and passes with it
- [x] Existing removal test (`invokes the watch callback with nlink 0`) and never-existed test still pass (now ~300-500ms instead of instant, comfortably within the mocha timeout)
- [x] Full suite green: `yarn lint && yarn typecheck && yarn test` (153 passing)
- [x] Coverage above the enforced gate: 96.3%/85.81%/90.19%/96.3% vs. 93/80/85/93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_