### PR TITLE
fix(#73): detect new directories created after startup

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -408,17 +408,48 @@ const lessWatchCompilerUtilsModule = {
             const file = path.join(f, b);
             if (!files[file]) {
               fs.stat(file, (err, stat) => {
+                if (err || !stat) return; // raced with a delete between readdir and stat
                 if (options.ignoreDotFiles && path.basename(b)[0] === '.') return;
-                if (options.filter && options.filter(b)) return;
+                // The extension filter must only apply to files -- a new
+                // directory (e.g. one created after startup) never matches
+                // an allowed extension, so applying the filter to it too
+                // would skip watching it (and everything created inside it
+                // afterward) entirely. walk() already gets this right for
+                // the initial recursive scan; mirror it here for new
+                // directories discovered later by this readdir rescan.
+                if (!stat.isDirectory() && options.filter && options.filter(b)) return;
                 fs.access(file, fs.constants.F_OK, (accessErr) => {
                   if (accessErr) {
                     console.log('Does not exist : ' + f);
-                  } else {
+                    return;
+                  }
+                  files[file] = stat as fs.Stats;
+                  if (!stat.isDirectory()) {
                     fileimportlist[file] = fileSearch.findLessImportsInFile(file);
                     watchCallback(file, stat as fs.Stats, null, fileimportlist);
-                    files[file] = stat as fs.Stats;
                     lessWatchCompilerUtilsModule.fileWatcher(file, files, options, filelist, fileimportlist, watchCallback);
+                    return;
                   }
+                  // A new directory: recursively discover anything already
+                  // inside it (a directory created together with files
+                  // already in it, e.g. via a project scaffold or an editor
+                  // batch operation, must not silently miss them -- issue
+                  // #73), the same way walk() does for directories found
+                  // during the initial scan, then start watching every
+                  // discovered file and subdirectory the same way the
+                  // initial scan does.
+                  lessWatchCompilerUtilsModule.walk(file, options, (walkErr, discovered) => {
+                    if (walkErr || !discovered) return;
+                    for (const p in discovered) {
+                      const s = discovered[p];
+                      files[p] = s;
+                      if (!s.isDirectory()) {
+                        fileimportlist[p] = fileSearch.findLessImportsInFile(p);
+                        watchCallback(p, s, null, fileimportlist);
+                      }
+                      lessWatchCompilerUtilsModule.fileWatcher(p, files, options, filelist, fileimportlist, watchCallback);
+                    }
+                  });
                 });
               });
             }

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -197,6 +197,67 @@ describe('lessWatchCompilerUtils Module API', function () {
         );
       });
 
+      it('detects and compiles a .less file inside a newly created directory (issue #73)', function (done) {
+        // filterFiles() rejects anything without an allowed extension, and a
+        // bare directory name never has one -- applying that filter to new
+        // directories (instead of only new files, like walk() already does
+        // for the initial scan) silently skipped watching them, and
+        // anything created inside them, forever.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-newdir-'));
+        const outDir = path.join(tmpDir, 'css');
+        fs.mkdirSync(outDir);
+        fs.writeFileSync(path.join(tmpDir, 'existing.less'), '.x { color: red; }');
+
+        lessWatchCompilerUtils.config = { watchFolder: tmpDir, outputFolder: outDir };
+
+        function cleanup() {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        lessWatchCompilerUtils.watchTree(
+          tmpDir,
+          { interval: 30, filter: lessWatchCompilerUtils.filterFiles },
+          function (f, curr) {
+            if (typeof f === 'object' && curr === null) return;
+            if (curr && curr.nlink !== 0) lessWatchCompilerUtils.compileCSS(f);
+          },
+          function (f) {
+            lessWatchCompilerUtils.compileCSS(f);
+          }
+        );
+
+        waitForFileContent(
+          path.join(outDir, 'existing.css'),
+          (c) => c.includes('red'),
+          3000,
+          (err) => {
+            if (err) {
+              cleanup();
+              return done(err);
+            }
+            setTimeout(() => {
+              // Create the directory and the file inside it back-to-back,
+              // matching the original report ("create new directory, create
+              // xxx.less inside") and exercising the tighter race where the
+              // file already exists by the time the new directory itself is
+              // discovered.
+              fs.mkdirSync(path.join(tmpDir, 'newdir'));
+              fs.writeFileSync(path.join(tmpDir, 'newdir', 'nested.less'), '.y { color: green; }');
+              waitForFileContent(
+                path.join(outDir, 'newdir', 'nested.css'),
+                (c) => c.includes('green'),
+                5000,
+                (err2) => {
+                  cleanup();
+                  if (err2) return done(err2);
+                  done();
+                }
+              );
+            }, 100);
+          }
+        );
+      });
+
       it('invokes the watch callback with nlink 0 (and does not crash) when a watched file is deleted', function (done) {
         const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-remove-'));
         const outDir = path.join(tmpDir, 'css');


### PR DESCRIPTION
## **User description**
## Summary

Fixes #73.

`setupWatcher()`'s directory readdir-rescan applied the extension filter to every newly-discovered entry, including directories. A bare directory name never matches an allowed extension (`.less` by default), so `filterFiles()` rejected every new directory — it was never watched, and anything created inside it afterward (matching the original report: "create new directory, create xxx.less inside") went completely undetected, silently. `walk()` already gets this right for the initial recursive scan (it only applies the filter to files, guarding on `!st.isDirectory()`); this mirrors that same guard for directories discovered later during live watching.

A new directory can also arrive with files already inside it (created back-to-back — a scaffold script, an editor batch operation, or just a fast script). `fs.watchFile`'s baseline is captured at registration time, so simply starting to watch the new directory wouldn't notice files that already existed the moment watching began. Reused `walk()` on the newly-discovered directory's subtree (the same function that already correctly handles this for the initial scan) to pick those up too, instead of only reacting to changes from that point forward.

Also, while fixing this:
- Added an `err`/`stat` guard before the new `stat.isDirectory()` check, closing a latent (if narrow) crash risk on a delete-between-readdir-and-stat race.
- Stopped a bare directory from being passed to `compileCSS()` as if it were a changed file — previously this would have thrown `EISDIR` trying to read it as LESS source (and called `process.exit(1)` under `--run-once`, i.e. simply creating an empty directory during a CI build could have produced a spurious nonzero exit).

## Test plan

- [x] Reproduced the exact original report against the real CLI before fixing (no crash, no error, no CSS output — silently nothing happens) and confirmed the fix resolves it, output correctly mirrors the new directory structure
- [x] Also verified the "file already present when the directory is discovered" race and the "empty new directory doesn't crash or spuriously error" case directly against the CLI
- [x] New regression test (real `fs.watchFile`, not mocked) — confirmed it fails without the fix (times out) and passes with it
- [x] Full suite green: `yarn lint && yarn typecheck && yarn test` (155 passing)
- [x] Coverage above the enforced gate: 96.36%/85.23%/90.19%/96.36% vs. 93/80/85/93

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
**Detect and compile LESS files created inside new directories after startup**

### What Changed
- New folders created while watching are now picked up, so LESS files added inside them are compiled instead of being missed.
- If a new folder already contains files when it appears, those files are discovered and compiled right away.
- Empty folders or files deleted during scanning no longer cause the watcher to fail or try to process a folder like a file.
- Added coverage for creating a new folder and then adding a LESS file inside it.

### Impact
`✅ New folders are watched correctly`
`✅ Fewer missed style builds`
`✅ Clearer handling of folder creation during watch`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
