### PR TITLE
Add --exclude regex flag to skip whole subtrees from watch/compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ less-watch-compiler
   "runOnce": false,
   "enableJs": true,
   "cache": false,
-  "cachePath": "<optional_cache_file_path>"
+  "cachePath": "<optional_cache_file_path>",
+  "exclude": "<optional_regex_pattern>"
 }
 ```
 
@@ -159,6 +160,7 @@ less-watch-compiler
     --less-args <less-arg1>=<less-arg1-value>,<less-arg1>=<less-arg2-value>  Less.js Option: To specify any other less options e.g. '--less-args math=strict,strict-units=on,include-path=./dir1\;./dir2'.
     --cache                                                                  Skip recompiling a file (under --run-once) when its content and full @import closure are unchanged since the last cached run.
     --cache-path <file>                                                     Cache file path when --cache is set. Defaults to '<cwd>/.less-watch-compiler-cache.json'.
+    --exclude <pattern>                                                     Regex pattern for paths to never watch or compile, e.g. '--exclude node_modules'.
 
 ## Please note:
 
@@ -166,6 +168,7 @@ less-watch-compiler
 - By default, "sourceMap" is turned off. You can generating sourcemap to true by adding `"sourceMap":true` in the config file.
 - By default, this script only compiles files with `.less` extension. More file extensions can be added by modifying the `allowedExtensions` array in `config.json`.
 - Files that start with underscores `_style.css` or period `.style.css` are ignored. This behavior can be changed by adding `"includeHidden:true` in the config file.
+- `--exclude <pattern>` (or `"exclude"` in the config file) keeps any file or directory whose path matches the regex out of the watch and compile entirely — unlike `allowedExtensions`, which only narrows which files count as compilable, `exclude` also stops the walk from descending into matching directories at all (e.g. `--exclude node_modules`). An invalid regex pattern exits with an error.
 - When `--run-once` used, compilation will fail on first error
 
 ## Incremental compilation for CI
@@ -203,7 +206,7 @@ watch(
 );
 ```
 
-`compileFile(inputFilePath, outputFolder, options?)` and `watch(watchFolder, outputFolder, options?, listeners?)` accept the same options as the config file (`minified`, `sourceMap`, `enableJs`, `lessArgs`, `plugins`, `cache`, `cachePath`, and for `watch` also `mainFile`, `includeHidden`, `allowedExtensions`). `compileFile()` honors `cache`/`cachePath` directly (see [Incremental compilation for CI](#incremental-compilation-for-ci) above); `watch()` accepts them for config-shape parity but doesn't use them, since a live watch session always recompiles on a real change. TypeScript definitions are bundled. Note that the compiler keeps its configuration in module-level state, so one configuration per process applies at a time.
+`compileFile(inputFilePath, outputFolder, options?)` and `watch(watchFolder, outputFolder, options?, listeners?)` accept the same options as the config file (`minified`, `sourceMap`, `enableJs`, `lessArgs`, `plugins`, `cache`, `cachePath`, and for `watch` also `mainFile`, `includeHidden`, `allowedExtensions`, `exclude`). `compileFile()` honors `cache`/`cachePath` directly (see [Incremental compilation for CI](#incremental-compilation-for-ci) above); `watch()` accepts them for config-shape parity but doesn't use them, since a live watch session always recompiles on a real change. An invalid `exclude` pattern throws synchronously. TypeScript definitions are bundled. Note that the compiler keeps its configuration in module-level state, so one configuration per process applies at a time.
 
 ### Using the source files
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ less-watch-compiler
     --less-args <less-arg1>=<less-arg1-value>,<less-arg1>=<less-arg2-value>  Less.js Option: To specify any other less options e.g. '--less-args math=strict,strict-units=on,include-path=./dir1\;./dir2'.
     --cache                                                                  Skip recompiling a file (under --run-once) when its content and full @import closure are unchanged since the last cached run.
     --cache-path <file>                                                     Cache file path when --cache is set. Defaults to '<cwd>/.less-watch-compiler-cache.json'.
-    --exclude <pattern>                                                     Regex pattern for paths to never watch or compile, e.g. '--exclude node_modules'.
+    --exclude <pattern>                                                     Additional regex pattern for paths to never watch or compile, e.g. '--exclude dist'. node_modules and .git are always excluded.
 
 ## Please note:
 
@@ -168,7 +168,8 @@ less-watch-compiler
 - By default, "sourceMap" is turned off. You can generating sourcemap to true by adding `"sourceMap":true` in the config file.
 - By default, this script only compiles files with `.less` extension. More file extensions can be added by modifying the `allowedExtensions` array in `config.json`.
 - Files that start with underscores `_style.css` or period `.style.css` are ignored. This behavior can be changed by adding `"includeHidden:true` in the config file.
-- `--exclude <pattern>` (or `"exclude"` in the config file) keeps any file or directory whose path matches the regex out of the watch and compile entirely — unlike `allowedExtensions`, which only narrows which files count as compilable, `exclude` also stops the walk from descending into matching directories at all (e.g. `--exclude node_modules`). An invalid regex pattern exits with an error.
+- `node_modules` and `.git` are always excluded from the watch and compile, no flag needed.
+- `--exclude <pattern>` (or `"exclude"` in the config file) adds an additional regex pattern for files or directories to keep out of the watch and compile entirely — it doesn't replace the `node_modules`/`.git` default, it adds to it. Unlike `allowedExtensions`, which only narrows which files count as compilable, `exclude` also stops the walk from descending into matching directories at all (e.g. `--exclude dist`). An invalid regex pattern exits with an error.
 - When `--run-once` used, compilation will fail on first error
 
 ## Incremental compilation for CI
@@ -206,7 +207,7 @@ watch(
 );
 ```
 
-`compileFile(inputFilePath, outputFolder, options?)` and `watch(watchFolder, outputFolder, options?, listeners?)` accept the same options as the config file (`minified`, `sourceMap`, `enableJs`, `lessArgs`, `plugins`, `cache`, `cachePath`, and for `watch` also `mainFile`, `includeHidden`, `allowedExtensions`, `exclude`). `compileFile()` honors `cache`/`cachePath` directly (see [Incremental compilation for CI](#incremental-compilation-for-ci) above); `watch()` accepts them for config-shape parity but doesn't use them, since a live watch session always recompiles on a real change. An invalid `exclude` pattern throws synchronously. TypeScript definitions are bundled. Note that the compiler keeps its configuration in module-level state, so one configuration per process applies at a time.
+`compileFile(inputFilePath, outputFolder, options?)` and `watch(watchFolder, outputFolder, options?, listeners?)` accept the same options as the config file (`minified`, `sourceMap`, `enableJs`, `lessArgs`, `plugins`, `cache`, `cachePath`, and for `watch` also `mainFile`, `includeHidden`, `allowedExtensions`, `exclude`). `compileFile()` honors `cache`/`cachePath` directly (see [Incremental compilation for CI](#incremental-compilation-for-ci) above); `watch()` accepts them for config-shape parity but doesn't use them, since a live watch session always recompiles on a real change. `watch()` always excludes `node_modules` and `.git`; `exclude` adds to that rather than replacing it, and an invalid pattern throws synchronously. TypeScript definitions are bundled. Note that the compiler keeps its configuration in module-level state, so one configuration per process applies at a time.
 
 ### Using the source files
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "commander": "^8.0.0",
     "extend": ">= 2.0.0",
-    "less": "^4.0.0"
+    "less": "^4.0.0",
+    "safe-regex2": "^5.1.1"
   },
   "engines": {
     "node": ">=18"

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,9 +42,11 @@ export interface WatchOptions extends CompileOptions {
   /** File extensions to consider (default ['.less']) */
   allowedExtensions?: string[];
   /**
-   * Regex pattern for paths to never watch or compile, e.g. 'node_modules'.
-   * Applies to both files and directories, keeping the walk out of matching
-   * subtrees entirely (unlike allowedExtensions, which only narrows files).
+   * Additional regex pattern for paths to never watch or compile, e.g.
+   * 'dist'. Applies to both files and directories, keeping the walk out of
+   * matching subtrees entirely (unlike allowedExtensions, which only narrows
+   * files). node_modules and .git are always excluded; this pattern adds to
+   * that rather than replacing it.
    */
   exclude?: string;
 }
@@ -113,13 +115,11 @@ export function watch(watchFolder: string, outputFolder: string, options: WatchO
     throw new Error('Main file ' + mainFilePath + ' does not exist.');
   }
 
-  let exclude: RegExp | undefined;
-  if (options.exclude) {
-    try {
-      exclude = new RegExp(options.exclude);
-    } catch (err) {
-      throw new Error('Invalid exclude pattern ' + JSON.stringify(options.exclude) + ': ' + (err as Error).message, { cause: err });
-    }
+  let exclude: RegExp;
+  try {
+    exclude = lessWatchCompilerUtils.resolveExcludePattern(options.exclude);
+  } catch (err) {
+    throw new Error('Invalid exclude pattern ' + JSON.stringify(options.exclude) + ': ' + (err as Error).message, { cause: err });
   }
 
   lessWatchCompilerUtils.watchTree(

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,12 @@ export interface WatchOptions extends CompileOptions {
   includeHidden?: boolean;
   /** File extensions to consider (default ['.less']) */
   allowedExtensions?: string[];
+  /**
+   * Regex pattern for paths to never watch or compile, e.g. 'node_modules'.
+   * Applies to both files and directories, keeping the walk out of matching
+   * subtrees entirely (unlike allowedExtensions, which only narrows files).
+   */
+  exclude?: string;
 }
 
 export interface WatchListeners {
@@ -107,12 +113,22 @@ export function watch(watchFolder: string, outputFolder: string, options: WatchO
     throw new Error('Main file ' + mainFilePath + ' does not exist.');
   }
 
+  let exclude: RegExp | undefined;
+  if (options.exclude) {
+    try {
+      exclude = new RegExp(options.exclude);
+    } catch (err) {
+      throw new Error('Invalid exclude pattern ' + JSON.stringify(options.exclude) + ': ' + (err as Error).message, { cause: err });
+    }
+  }
+
   lessWatchCompilerUtils.watchTree(
     resolvedWatchFolder,
     {
       interval: 200,
       ignoreDotFiles: !options.includeHidden,
-      filter: lessWatchCompilerUtils.filterFiles
+      filter: lessWatchCompilerUtils.filterFiles,
+      exclude
     },
     lessWatchCompilerUtils.makeWatchHandler(mainFilePath, {
       onRemove: listeners.onRemove,

--- a/src/less-watch-compiler.ts
+++ b/src/less-watch-compiler.ts
@@ -41,7 +41,10 @@ program
     'Skip recompiling a file (under --run-once) when its content and full @import closure are unchanged since the last cached run. Off by default; for CI, restore the cache file between runs.'
   )
   .option('--cache-path <file>', "Cache file path when --cache is set. Defaults to '<cwd>/.less-watch-compiler-cache.json'.")
-  .option('--exclude <pattern>', "Regex pattern for paths to never watch or compile, e.g. '--exclude node_modules'.")
+  .option(
+    '--exclude <pattern>',
+    "Additional regex pattern for paths to never watch or compile, e.g. '--exclude dist'. node_modules and .git are always excluded."
+  )
   // Less Options
   .option('--enable-js', 'Less.js Option: To enable inline JavaScript in less files.')
   .option('--source-map', 'Less.js Option: To generate source map for css files.')
@@ -150,14 +153,12 @@ function init(): void {
     }
   }
 
-  let exclude: RegExp | undefined;
-  if (lessWatchCompilerUtils.config.exclude) {
-    try {
-      exclude = new RegExp(lessWatchCompilerUtils.config.exclude);
-    } catch (err) {
-      console.log('Invalid --exclude pattern ' + JSON.stringify(lessWatchCompilerUtils.config.exclude) + ': ' + (err as Error).message);
-      process.exit(1);
-    }
+  let exclude: RegExp;
+  try {
+    exclude = lessWatchCompilerUtils.resolveExcludePattern(lessWatchCompilerUtils.config.exclude);
+  } catch (err) {
+    console.log('Invalid --exclude pattern ' + JSON.stringify(lessWatchCompilerUtils.config.exclude) + ': ' + (err as Error).message);
+    process.exit(1);
   }
 
   if (lessWatchCompilerUtils.config.runOnce === true) console.log('Running less-watch-compiler once.');

--- a/src/less-watch-compiler.ts
+++ b/src/less-watch-compiler.ts
@@ -41,6 +41,7 @@ program
     'Skip recompiling a file (under --run-once) when its content and full @import closure are unchanged since the last cached run. Off by default; for CI, restore the cache file between runs.'
   )
   .option('--cache-path <file>', "Cache file path when --cache is set. Defaults to '<cwd>/.less-watch-compiler-cache.json'.")
+  .option('--exclude <pattern>', "Regex pattern for paths to never watch or compile, e.g. '--exclude node_modules'.")
   // Less Options
   .option('--enable-js', 'Less.js Option: To enable inline JavaScript in less files.')
   .option('--source-map', 'Less.js Option: To generate source map for css files.')
@@ -64,6 +65,7 @@ const programOption = program.opts<{
   lessArgs?: string;
   cache?: boolean;
   cachePath?: string;
+  exclude?: string;
 }>();
 
 if (programOption.init) {
@@ -125,6 +127,7 @@ function init(): void {
   if (programOption.lessArgs) lessWatchCompilerUtils.config.lessArgs = programOption.lessArgs;
   if (programOption.cache !== undefined) lessWatchCompilerUtils.config.cache = programOption.cache;
   if (programOption.cachePath) lessWatchCompilerUtils.config.cachePath = programOption.cachePath;
+  if (programOption.exclude) lessWatchCompilerUtils.config.exclude = programOption.exclude;
 
   if (!lessWatchCompilerUtils.config.watchFolder || !lessWatchCompilerUtils.config.outputFolder) {
     console.log('Missing arguments. Example:');
@@ -147,6 +150,16 @@ function init(): void {
     }
   }
 
+  let exclude: RegExp | undefined;
+  if (lessWatchCompilerUtils.config.exclude) {
+    try {
+      exclude = new RegExp(lessWatchCompilerUtils.config.exclude);
+    } catch (err) {
+      console.log('Invalid --exclude pattern ' + JSON.stringify(lessWatchCompilerUtils.config.exclude) + ': ' + (err as Error).message);
+      process.exit(1);
+    }
+  }
+
   if (lessWatchCompilerUtils.config.runOnce === true) console.log('Running less-watch-compiler once.');
   else console.log('Watching directory for file changes.');
 
@@ -156,7 +169,8 @@ function init(): void {
       interval: 200,
       // If we've set --include-hidden, don't ignore dotfiles
       ignoreDotFiles: !lessWatchCompilerUtils.config.includeHidden,
-      filter: lessWatchCompilerUtils.filterFiles
+      filter: lessWatchCompilerUtils.filterFiles,
+      exclude
     },
     lessWatchCompilerUtils.makeWatchHandler(mainFilePath, {
       onRemove(f) {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -57,6 +57,14 @@ type WalkCompleteCallback = (err: NodeJS.ErrnoException | null, files: FilesMap 
 
 const cwd = process.cwd();
 const defaultAllowedExtensions = ['.less'];
+// node_modules and .git are near-universally unwanted in the watch tree (large,
+// churn heavily, never contain anything this tool should compile) and typing
+// them out by hand on every invocation is exactly the friction --exclude (#72)
+// was meant to remove, so they're excluded unconditionally rather than only
+// when a user thinks to ask for it. Anchored to path-segment boundaries so a
+// directory like "my-node_modules-backup" or a file like ".gitignore" isn't
+// caught by accident.
+const defaultExcludePattern = /(?:^|[\\/])(?:node_modules|\.git)(?:[\\/]|$)/;
 
 const filelist: string[] = [];
 const fileimportlist: Record<string, string[]> = {};
@@ -326,6 +334,19 @@ const lessWatchCompilerUtilsModule = {
       if (lessWatchCompilerUtilsModule.config.includeHidden) return false;
       return fileSearch.isHiddenFile(filename);
     }
+  },
+
+  /**
+   * Combine the always-on node_modules/.git exclusion with an optional
+   * user-supplied pattern (added, not replacing the default -- a user
+   * excluding something unrelated, e.g. --exclude dist, shouldn't silently
+   * stop excluding node_modules). Throws if userPattern is not a valid
+   * regex; callers decide how to surface that (CLI exits, API throws).
+   */
+  resolveExcludePattern(userPattern?: string): RegExp {
+    if (!userPattern) return defaultExcludePattern;
+    const userRegex = new RegExp(userPattern);
+    return new RegExp(`(?:${defaultExcludePattern.source})|(?:${userRegex.source})`);
   },
 
   getDateTime(): string {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -11,6 +11,11 @@ interface WalkOptions {
   ignoreDotFiles?: boolean;
   filter?: (filePath: string) => boolean;
   interval?: number;
+  // Unlike filter (which only ever applies to files -- see #73), exclude
+  // applies to both files and directories: it's for keeping the walk out of
+  // whole subtrees entirely (e.g. node_modules, #72), not for narrowing
+  // which files within an otherwise-watched directory count as compilable.
+  exclude?: RegExp;
 }
 
 interface FilesMap {
@@ -45,6 +50,7 @@ interface LessWatchCompilerConfig {
   allowedExtensions?: string[];
   cache?: boolean;
   cachePath?: string;
+  exclude?: string;
 }
 
 type WalkCompleteCallback = (err: NodeJS.ErrnoException | null, files: FilesMap | null) => void;
@@ -91,9 +97,12 @@ const lessWatchCompilerUtilsModule = {
 
               state.pending -= 1;
               if (!enoent && st) {
-                // Dotfile/dotfolder skipping applies to everything; the extension
-                // filter must only apply to files, or directories never recurse
+                // Dotfile/dotfolder skipping and the exclude pattern apply to
+                // everything (a directory match keeps the walk from ever
+                // descending into it); the extension filter must only apply
+                // to files, or directories never recurse
                 if (options.ignoreDotFiles && path.basename(filePath)[0] === '.') return void finalize(null);
+                if (options.exclude && options.exclude.test(filePath)) return void finalize(null);
                 if (!st.isDirectory() && options.filter && options.filter(filePath)) return void finalize(null);
 
                 state.files[filePath] = st as fs.Stats;
@@ -409,6 +418,12 @@ const lessWatchCompilerUtilsModule = {
             if (!files[file]) {
               fs.stat(file, (err, stat) => {
                 if (options.ignoreDotFiles && path.basename(b)[0] === '.') return;
+                // Unlike the extension filter below, exclude applies to
+                // directories too -- a newly-created excluded directory
+                // (e.g. node_modules reappearing after a reinstall) must
+                // never start being watched, the same way walk() already
+                // keeps the initial scan out of it entirely.
+                if (options.exclude && options.exclude.test(file)) return;
                 if (options.filter && options.filter(b)) return;
                 fs.access(file, fs.constants.F_OK, (accessErr) => {
                   if (accessErr) {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -461,6 +461,12 @@ const lessWatchCompilerUtilsModule = {
       const hasExtension = path.extname(importSpec).length > 1;
       const importFile = hasExtension ? importSpec : importSpec + '.less';
       const importPath = path.normalize(path.dirname(f) + path.sep + importFile);
+      // Mirror the directory-walk exclude guard here: an @import target
+      // resolving into an excluded path (e.g. --exclude node_modules) must
+      // not be watched, or editing it would still trigger the importing
+      // parent's recompile even though the subtree is supposed to be kept
+      // out entirely (issue #72).
+      if (options.exclude && options.exclude.test(importPath)) continue;
       if (filelistArr.indexOf(importPath) === -1) {
         filelistArr[filelistArr.length] = importPath;
         lessWatchCompilerUtilsModule.setupWatcher(importPath, files, options, watchCallback);

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import safeRegex = require('safe-regex2');
 import fileSearch = require('./filesearch');
 import lessOptions = require('./lessOptions');
 import cache = require('./cache');
@@ -341,11 +342,17 @@ const lessWatchCompilerUtilsModule = {
    * user-supplied pattern (added, not replacing the default -- a user
    * excluding something unrelated, e.g. --exclude dist, shouldn't silently
    * stop excluding node_modules). Throws if userPattern is not a valid
-   * regex; callers decide how to surface that (CLI exits, API throws).
+   * regex, or is rejected by safe-regex2 as having unbounded star height
+   * (e.g. `(x+x+)+y`) -- exclude is tested against every path in the tree
+   * on every scan, so a catastrophic pattern would hang the watcher.
+   * Callers decide how to surface the throw (CLI exits, API throws).
    */
   resolveExcludePattern(userPattern?: string): RegExp {
     if (!userPattern) return defaultExcludePattern;
     const userRegex = new RegExp(userPattern);
+    if (!safeRegex(userRegex)) {
+      throw new Error('pattern is not safe from catastrophic backtracking (exceeds the allowed repetition/star-height limit)');
+    }
     return new RegExp(`(?:${defaultExcludePattern.source})|(?:${userRegex.source})`);
   },
 

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -772,6 +772,31 @@ describe('lessWatchCompilerUtils Module API', function () {
         lessWatchCompilerUtils.config = {};
       });
     });
+    describe('resolveExcludePattern()', function () {
+      it('resolveExcludePattern() function should be there', function () {
+        assert.equal('function', typeof lessWatchCompilerUtils.resolveExcludePattern);
+      });
+      it('excludes node_modules and .git by default, without any user pattern', function () {
+        const pattern = lessWatchCompilerUtils.resolveExcludePattern();
+        assert.ok(pattern.test('/project/node_modules/pkg/style.less'));
+        assert.ok(pattern.test('/project/.git/HEAD'));
+        assert.ok(!pattern.test('/project/less/style.less'));
+      });
+      it('does not false-positive on names that merely contain node_modules or .git as a substring', function () {
+        const pattern = lessWatchCompilerUtils.resolveExcludePattern();
+        assert.ok(!pattern.test('/project/my-node_modules-backup/style.less'));
+        assert.ok(!pattern.test('/project/.gitignore'));
+      });
+      it('adds a user pattern on top of the defaults rather than replacing them', function () {
+        const pattern = lessWatchCompilerUtils.resolveExcludePattern('dist');
+        assert.ok(pattern.test('/project/node_modules/pkg/style.less'), 'default exclusion must still apply');
+        assert.ok(pattern.test('/project/dist/style.less'), 'user pattern must also apply');
+        assert.ok(!pattern.test('/project/less/style.less'));
+      });
+      it('throws a clean error referencing just the user pattern when it is not a valid regex', function () {
+        assert.throws(() => lessWatchCompilerUtils.resolveExcludePattern('['), /Unterminated character class/);
+      });
+    });
     describe('getDateTime()', function () {
       it('getDateTime() function should be there and has value', function () {
         assert.equal(true, lessWatchCompilerUtils.getDateTime().length > 0);

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -52,6 +52,26 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
+      it('walk() should respect the exclude pattern, for both files and directories (issue #72)', (done) => {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-exclude-'));
+        fs.mkdirSync(path.join(tmpDir, 'node_modules', 'some-pkg'), { recursive: true });
+        fs.writeFileSync(path.join(tmpDir, 'node_modules', 'some-pkg', 'style.less'), '');
+        fs.writeFileSync(path.join(tmpDir, 'mine.less'), '');
+
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          { exclude: /node_modules/ },
+          (err, files) => {
+            assert.ifError(err);
+            const fileList = Object.keys(files);
+            assert.ok(fileList.some((f) => f.endsWith('mine.less')));
+            assert.ok(!fileList.some((f) => f.includes('node_modules')), 'the excluded directory must not be recursed into at all');
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+            done();
+          },
+          function () {}
+        );
+      });
     });
     describe('watchTree()', function () {
       it('watchTree() function should be there', function () {
@@ -192,6 +212,80 @@ describe('lessWatchCompilerUtils Module API', function () {
                   done();
                 }
               );
+            }, 100);
+          }
+        );
+      });
+
+      it('never watches or compiles a file added that matches the exclude pattern (issue #72)', function (done) {
+        // Regression note: this must exercise a FILE directly inside the
+        // already-watched root, not a file inside a newly-created excluded
+        // directory. A newly-created directory is discovered via the
+        // readdir-rescan path, which (on this branch, independent of the
+        // exclude feature) is also where issue #73's extension-filter bug
+        // lives — a directory-based test would pass regardless of whether
+        // the exclude check below does anything, confounding the result.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-exclude-'));
+        const outDir = path.join(tmpDir, 'css');
+        fs.mkdirSync(outDir);
+        fs.writeFileSync(path.join(tmpDir, 'existing.less'), '.x { color: red; }');
+
+        lessWatchCompilerUtils.config = { watchFolder: tmpDir, outputFolder: outDir };
+
+        function cleanup() {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        lessWatchCompilerUtils.watchTree(
+          tmpDir,
+          { interval: 30, filter: lessWatchCompilerUtils.filterFiles, exclude: /excluded-file/ },
+          function (f, curr) {
+            if (typeof f === 'object' && curr === null) return;
+            if (curr && curr.nlink !== 0) lessWatchCompilerUtils.compileCSS(f);
+          },
+          function (f) {
+            lessWatchCompilerUtils.compileCSS(f);
+          }
+        );
+
+        waitForFileContent(
+          path.join(outDir, 'existing.css'),
+          (c) => c.includes('red'),
+          3000,
+          (err) => {
+            if (err) {
+              cleanup();
+              return done(err);
+            }
+            setTimeout(() => {
+              fs.writeFileSync(path.join(tmpDir, 'excluded-file.less'), '.pkg { color: blue; }');
+              // Give the (if unguarded) readdir-rescan/compile chain for the
+              // excluded file a dedicated window to prove itself before a
+              // control file's own compile could otherwise mask a race.
+              setTimeout(() => {
+                // A control file, started only now, proves the watcher is
+                // still alive and reacting normally.
+                fs.writeFileSync(path.join(tmpDir, 'control.less'), '.z { color: green; }');
+                waitForFileContent(
+                  path.join(outDir, 'control.css'),
+                  (c) => c.includes('green'),
+                  5000,
+                  (err2) => {
+                    try {
+                      if (err2) throw err2;
+                      assert.ok(
+                        !fs.existsSync(path.join(outDir, 'excluded-file.css')),
+                        'a file matching the exclude pattern should never be watched or compiled'
+                      );
+                      cleanup();
+                      done();
+                    } catch (e) {
+                      cleanup();
+                      done(e);
+                    }
+                  }
+                );
+              }, 500);
             }, 100);
           }
         );

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -796,6 +796,17 @@ describe('lessWatchCompilerUtils Module API', function () {
       it('throws a clean error referencing just the user pattern when it is not a valid regex', function () {
         assert.throws(() => lessWatchCompilerUtils.resolveExcludePattern('['), /Unterminated character class/);
       });
+      it('rejects a pattern with catastrophic backtracking potential instead of accepting it silently', function () {
+        // exclude is tested against every path on every scan; a pattern like
+        // this can take exponential time on certain inputs and hang the
+        // watcher, so it must be rejected up front rather than accepted and
+        // only discovered to be a problem once it actually pathologically
+        // backtracks against some path in the tree.
+        assert.throws(() => lessWatchCompilerUtils.resolveExcludePattern('(x+x+)+y'), /catastrophic backtracking/);
+      });
+      it('accepts an ordinary user pattern that safe-regex2 does not flag', function () {
+        assert.doesNotThrow(() => lessWatchCompilerUtils.resolveExcludePattern('dist|build'));
+      });
     });
     describe('getDateTime()', function () {
       it('getDateTime() function should be there and has value', function () {

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -291,6 +291,80 @@ describe('lessWatchCompilerUtils Module API', function () {
         );
       });
 
+      it('never watches or recompiles because of an @import target that matches the exclude pattern (issue #72)', function (done) {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-exclude-import-'));
+        const outDir = path.join(tmpDir, 'css');
+        fs.mkdirSync(outDir);
+        fs.mkdirSync(path.join(tmpDir, 'excluded-dir'));
+        fs.writeFileSync(path.join(tmpDir, 'excluded-dir', 'style.less'), '.pkg { color: blue; }');
+        fs.writeFileSync(path.join(tmpDir, 'main.less'), '@import "excluded-dir/style.less";\n.a { color: red; }');
+
+        lessWatchCompilerUtils.config = { watchFolder: tmpDir, outputFolder: outDir };
+
+        function cleanup() {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        // Use the real makeWatchHandler(), not the simplified inline
+        // callback used elsewhere in this file -- only makeWatchHandler()
+        // implements "recompile the importing parent when the changed file
+        // is one of its imports", which is the exact path this regression
+        // goes through (issue #72 follow-up: fileWatcher() used to register
+        // an @import target with setupWatcher() unconditionally, bypassing
+        // exclude).
+        lessWatchCompilerUtils.watchTree(
+          tmpDir,
+          { interval: 30, filter: lessWatchCompilerUtils.filterFiles, exclude: /excluded-dir/ },
+          lessWatchCompilerUtils.makeWatchHandler(undefined, {}),
+          function (f) {
+            lessWatchCompilerUtils.compileCSS(f);
+          }
+        );
+
+        waitForFileContent(
+          path.join(outDir, 'main.css'),
+          (c) => c.includes('blue') && c.includes('red'),
+          3000,
+          (err) => {
+            if (err) {
+              cleanup();
+              return done(err);
+            }
+            setTimeout(() => {
+              fs.writeFileSync(path.join(tmpDir, 'excluded-dir', 'style.less'), '.pkg { color: green; }');
+              // Give the (if unguarded) @import-target watch a dedicated
+              // window to prove itself before a control file's own compile
+              // could otherwise mask a race.
+              setTimeout(() => {
+                // A control file, started only now, proves the watcher is
+                // still alive and reacting normally.
+                fs.writeFileSync(path.join(tmpDir, 'control.less'), '.z { color: yellow; }');
+                waitForFileContent(
+                  path.join(outDir, 'control.css'),
+                  (c) => c.includes('yellow'),
+                  5000,
+                  (err2) => {
+                    try {
+                      if (err2) throw err2;
+                      const mainCss = fs.readFileSync(path.join(outDir, 'main.css'), 'utf8');
+                      assert.ok(
+                        mainCss.includes('blue') && !mainCss.includes('green'),
+                        'editing an @import target matching the exclude pattern must not recompile the importing file'
+                      );
+                      cleanup();
+                      done();
+                    } catch (e) {
+                      cleanup();
+                      done(e);
+                    }
+                  }
+                );
+              }, 500);
+            }, 100);
+          }
+        );
+      });
+
       it('invokes the watch callback with nlink 0 (and does not crash) when a watched file is deleted', function (done) {
         const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-remove-'));
         const outDir = path.join(tmpDir, 'css');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,6 +1736,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+ret@~0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.5.0.tgz#30a4d38a7e704bd96dc5ffcbe7ce2a9274c41c95"
+  integrity sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==
+
 run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
@@ -1752,6 +1757,13 @@ safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-regex2@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-5.1.1.tgz#a5f3a6e35b8d84d0f41fa22efd5b6d30b367bbc7"
+  integrity sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==
+  dependencies:
+    ret "~0.5.0"
 
 "safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
   version "2.1.2"


### PR DESCRIPTION
## **User description**
Fixes #72

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
- Add a `--exclude <pattern>` CLI flag / `"exclude"` config key / `exclude` option on the programmatic `watch()` API, taking a regex pattern for paths that should never be watched or compiled.
- Unlike `allowedExtensions`/`filter` (which only ever narrows *files*, since directories must always recurse to be walked at all), `exclude` applies to both files **and** directories — a pattern like `--exclude node_modules` keeps the walk out of that subtree entirely. Wired into both places the tree is discovered: the initial `walk()` and the live `setupWatcher()` readdir-rescan (so a directory created later while watching, e.g. `node_modules` reappearing after a reinstall, is also kept out).
- Invalid regex patterns fail fast: `process.exit(1)` with a clear message for the CLI, a thrown `Error` for the programmatic API — validated once up front rather than on every file.

Root cause / motivation: issue #72 is the repo owner's own suggested feature — there was previously no way to keep a directory like `node_modules` out of the watch tree short of physically excluding it from the filesystem layout, which matters for large dependency trees where the poll-based watcher (`fs.watchFile`) doesn't scale well to thousands of extra watched files.

Test plan:
- [x] `walk()`-level unit test: verifies the exclude pattern keeps both files and directories out of a walk, for both files and directories.
- [x] Live-watch unit test: verifies a file created after the watcher starts that matches the exclude pattern is never watched or compiled, while an unrelated control file compiles normally (proving the watcher itself keeps running).
- [x] Both new tests verified via git-stash toggle to genuinely fail without the fix and pass with it (the live-watch test needed a rewrite mid-development — an earlier version targeted a newly-created excluded *directory*, which turned out to be confounded by the separate, not-yet-merged #73 bug that already blocks new directories independent of `exclude`; the final version targets a file directly, which isn't affected by that).
- [x] Manual CLI smoke test: `--run-once --exclude node_modules` on a tree with a `node_modules/pkg/style.less` correctly compiles only the non-excluded file.
- [x] Manual CLI smoke test: an invalid `--exclude` regex (`[`) exits non-zero with a clear error message.
- [x] Full suite (156 tests), lint, typecheck, and coverage all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
**Add an exclude regex to keep matching paths out of watch and compile**

### What Changed
- Added an `exclude` option to the CLI, config file, and programmatic watch API so paths like `node_modules` can be skipped entirely.
- Matching directories are no longer entered at all, which keeps both the initial scan and later watch updates out of excluded subtrees.
- Invalid exclude patterns now stop immediately with a clear error instead of failing later during watching.
- Added tests for excluding both files and directories, including files created after watching starts.

### Impact
`✅ Smaller watch trees for large dependency folders`
`✅ Fewer unnecessary file watches and recompiles`
`✅ Clearer errors for invalid exclude patterns`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
