### PR TITLE
Recompile every transitive @import ancestor, not just the direct one

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -164,8 +164,9 @@ const lessWatchCompilerUtilsModule = {
 
   /**
    * Build the standard change handler shared by the CLI and the programmatic
-   * API: recompiles the importing parent when a changed file is someone's
-   * @import, otherwise compiles the main file (when set) or the changed file.
+   * API: recompiles every importing ancestor (direct or transitive) when a
+   * changed file is someone's @import, otherwise compiles the main file
+   * (when set) or the changed file.
    */
   makeWatchHandler(
     mainFilePath: string | undefined,
@@ -182,24 +183,44 @@ const lessWatchCompilerUtilsModule = {
       } else if ((curr as fs.Stats).nlink === 0) {
         // f was removed
         if (notify.onRemove) notify.onRemove(f as string);
+      } else if (mainFilePath) {
+        // A single main file always wins, regardless of import relationships.
+        const compileResult = lessWatchCompilerUtilsModule.compileCSS(mainFilePath);
+        if (compileResult && notify.onCompile) notify.onCompile(f as string, compileResult);
       } else {
-        // f is a new file or changed
-        let importedFile = false;
-        for (const i in fileimports) {
-          for (const k in fileimports[i]) {
-            const hasExtension = path.extname(fileimports[i][k]).length > 1;
-            const importFile = hasExtension ? fileimports[i][k] : fileimports[i][k] + '.less';
-            const normalizedPath = path.normalize(path.dirname(i) + path.sep + importFile);
-
-            if (f === normalizedPath && !mainFilePath) {
-              const compileResult = lessWatchCompilerUtilsModule.compileCSS(i);
-              if (compileResult && notify.onImportCompile) notify.onImportCompile(i, f as string, compileResult);
-              importedFile = true;
+        // Find every file that imports `changed`, directly only (one hop);
+        // the caller walks this outward to cover the full transitive chain
+        // (e.g. homepage.less -> theme.less -> colors.less: editing
+        // colors.less must recompile homepage.less too, not just theme.less
+        // -- issue #59).
+        const directImporters = (changed: string): string[] => {
+          const result: string[] = [];
+          for (const i in fileimports) {
+            for (const k in fileimports[i]) {
+              const importSpec = fileimports[i][k];
+              const hasExtension = path.extname(importSpec).length > 1;
+              const importFile = hasExtension ? importSpec : importSpec + '.less';
+              const normalizedPath = path.normalize(path.dirname(i) + path.sep + importFile);
+              if (changed === normalizedPath) result.push(i);
             }
           }
+          return result;
+        };
+
+        const visited = new Set<string>();
+        const queue = directImporters(f as string);
+        while (queue.length > 0) {
+          const importer = queue.shift() as string;
+          if (visited.has(importer)) continue;
+          visited.add(importer);
+          const compileResult = lessWatchCompilerUtilsModule.compileCSS(importer);
+          if (compileResult && notify.onImportCompile) notify.onImportCompile(importer, f as string, compileResult);
+          queue.push(...directImporters(importer));
         }
-        if (!importedFile) {
-          const compileResult = lessWatchCompilerUtilsModule.compileCSS(mainFilePath || (f as string));
+
+        if (visited.size === 0) {
+          // Not anyone's import (transitively) -- compile the changed file itself.
+          const compileResult = lessWatchCompilerUtilsModule.compileCSS(f as string);
           if (compileResult && notify.onCompile) notify.onCompile(f as string, compileResult);
         }
       }
@@ -428,8 +449,16 @@ const lessWatchCompilerUtilsModule = {
       }
       files[f] = c as fs.Stats;
       if (!files[f].isDirectory()) {
-        if (options.ignoreDotFiles && path.basename(f)[0] === '.') return;
-        if (options.filter && options.filter(f)) return;
+        // Unlike the initial walk() scan (where filter/ignoreDotFiles decide
+        // whether a file is even discovered as a watch candidate at all),
+        // this per-file change callback must NOT apply those same checks
+        // before firing watchCallback: a hidden/filtered file that's only
+        // being watched because it's someone's @import target (e.g. the
+        // conventional _partial.less naming) still needs its change
+        // reported so makeWatchHandler() can find and recompile whatever
+        // imports it (issue #59) -- compileCSS() already independently
+        // skips producing standalone output for hidden files, which is the
+        // correct place for that guard, not here.
         fs.access(f, fs.constants.F_OK, (accessErr) => {
           if (accessErr) {
             console.log('Does not exist : ' + f);
@@ -526,10 +555,18 @@ const lessWatchCompilerUtilsModule = {
       // parent's recompile even though the subtree is supposed to be kept
       // out entirely (issue #72).
       if (options.exclude && options.exclude.test(importPath)) continue;
-      if (filelistArr.indexOf(importPath) === -1) {
-        filelistArr[filelistArr.length] = importPath;
-        lessWatchCompilerUtilsModule.setupWatcher(importPath, files, options, watchCallback);
-      }
+      // Recurse via fileWatcher(), not a bare setupWatcher() call: the
+      // latter registers the watch but never populates fileimportlistObj
+      // for the target, relying on a later top-level fileWatcher() call
+      // (from watchTree()'s walk-result loop) to do that instead. Depending
+      // on directory-walk discovery order, that later call can be pre-empted
+      // by fileWatcher()'s own dedup guard before it ever runs, permanently
+      // leaving the target's import list empty -- which silently breaks
+      // transitive-import recompile detection for anything importing IT
+      // (issue #59: homepage.less -> theme.less -> colors.less needs
+      // theme.less's own imports recorded for homepage.less to ever be
+      // reached when colors.less changes).
+      lessWatchCompilerUtilsModule.fileWatcher(importPath, files, options, filelistArr, fileimportlistObj, watchCallback);
       lessWatchCompilerUtilsModule.watchExternalImportDir(importPath, files, options, filelistArr, fileimportlistObj, watchCallback);
     }
   },

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -188,34 +188,38 @@ const lessWatchCompilerUtilsModule = {
         const compileResult = lessWatchCompilerUtilsModule.compileCSS(mainFilePath);
         if (compileResult && notify.onCompile) notify.onCompile(f as string, compileResult);
       } else {
-        // Find every file that imports `changed`, directly only (one hop);
-        // the caller walks this outward to cover the full transitive chain
-        // (e.g. homepage.less -> theme.less -> colors.less: editing
-        // colors.less must recompile homepage.less too, not just theme.less
-        // -- issue #59).
-        const directImporters = (changed: string): string[] => {
-          const result: string[] = [];
-          for (const i in fileimports) {
-            for (const k in fileimports[i]) {
-              const importSpec = fileimports[i][k];
-              const hasExtension = path.extname(importSpec).length > 1;
-              const importFile = hasExtension ? importSpec : importSpec + '.less';
-              const normalizedPath = path.normalize(path.dirname(i) + path.sep + importFile);
-              if (changed === normalizedPath) result.push(i);
-            }
+        // Build a reverse import index once (imported path -> importers)
+        // instead of rescanning the whole fileimports map on every BFS step
+        // -- with many files and a wide/deep import graph, doing that scan
+        // per node makes each change event scale quadratically.
+        const importersOf = new Map<string, string[]>();
+        for (const i in fileimports) {
+          for (const k in fileimports[i]) {
+            const importSpec = fileimports[i][k];
+            const hasExtension = path.extname(importSpec).length > 1;
+            const importFile = hasExtension ? importSpec : importSpec + '.less';
+            const normalizedPath = path.normalize(path.dirname(i) + path.sep + importFile);
+            const existing = importersOf.get(normalizedPath);
+            if (existing) existing.push(i);
+            else importersOf.set(normalizedPath, [i]);
           }
-          return result;
-        };
+        }
 
+        // Find every file that imports the changed file, directly and
+        // transitively (e.g. homepage.less -> theme.less -> colors.less:
+        // editing colors.less must recompile homepage.less too, not just
+        // theme.less -- issue #59), recompiling each ancestor exactly once
+        // (a visited set also terminates safely on circular imports).
         const visited = new Set<string>();
-        const queue = directImporters(f as string);
+        const queue = importersOf.get(f as string) || [];
         while (queue.length > 0) {
           const importer = queue.shift() as string;
           if (visited.has(importer)) continue;
           visited.add(importer);
           const compileResult = lessWatchCompilerUtilsModule.compileCSS(importer);
           if (compileResult && notify.onImportCompile) notify.onImportCompile(importer, f as string, compileResult);
-          queue.push(...directImporters(importer));
+          const grandImporters = importersOf.get(importer);
+          if (grandImporters) queue.push(...grandImporters);
         }
 
         if (visited.size === 0) {
@@ -555,6 +559,19 @@ const lessWatchCompilerUtilsModule = {
       // parent's recompile even though the subtree is supposed to be kept
       // out entirely (issue #72).
       if (options.exclude && options.exclude.test(importPath)) continue;
+      // Only follow @import targets with an allowed extension (.less by
+      // default). Less doesn't inline a plain `@import "x.css"` by default
+      // (it stays a literal `@import url(...)` reference in the compiled
+      // output), so treating such a target as its own watchable entry is
+      // both pointless -- recompiling on its change can't affect the
+      // importer's output -- and actively wrong, since it would let
+      // makeWatchHandler() compile it standalone and produce a spurious
+      // .css output for a file that was never meant to be compiled on its
+      // own. This must check extension only, NOT hidden-file status: a
+      // hidden _partial.less is exactly the kind of target issue #59 needs
+      // to keep following.
+      const importAllowedExtensions = lessWatchCompilerUtilsModule.config.allowedExtensions || defaultAllowedExtensions;
+      if (importAllowedExtensions.indexOf(path.extname(importPath)) === -1) continue;
       // Recurse via fileWatcher(), not a bare setupWatcher() call: the
       // latter registers the watch but never populates fileimportlistObj
       // for the target, relying on a later top-level fileWatcher() call

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -589,6 +589,73 @@ describe('lessWatchCompilerUtils Module API', function () {
           done();
         }, 500);
       });
+
+      it('recompiles the top-level entry file when a doubly-nested hidden partial changes (issue #59)', function (done) {
+        // homepage.less -> _theme.less -> _colors.less, both partials named
+        // with the conventional leading underscore (never compiled on their
+        // own). This exercises two compounding bugs together: (1)
+        // setupWatcher()'s per-file change callback used to apply the
+        // filter/hidden check before ever invoking watchCallback, silently
+        // swallowing changes to hidden @import targets entirely; and (2)
+        // makeWatchHandler() used to only check one hop of the import graph,
+        // so even with (1) fixed, a change to _colors.less would recompile
+        // _theme.less but never reach homepage.less two levels up.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-transitive-'));
+        const outDir = path.join(tmpDir, 'css');
+        fs.mkdirSync(outDir);
+        fs.writeFileSync(path.join(tmpDir, 'homepage.less'), '@import "_theme.less";\n.a { color: red; }');
+        fs.writeFileSync(path.join(tmpDir, '_theme.less'), '@import "_colors.less";\n.theme { .mixin(); }');
+        fs.writeFileSync(path.join(tmpDir, '_colors.less'), '.mixin() { color: blue; }');
+
+        lessWatchCompilerUtils.config = { watchFolder: tmpDir, outputFolder: outDir };
+
+        function cleanup() {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        lessWatchCompilerUtils.watchTree(
+          tmpDir,
+          { interval: 30, filter: lessWatchCompilerUtils.filterFiles },
+          lessWatchCompilerUtils.makeWatchHandler(undefined, {}),
+          function (f) {
+            lessWatchCompilerUtils.compileCSS(f);
+          }
+        );
+
+        waitForFileContent(
+          path.join(outDir, 'homepage.css'),
+          (c) => c.includes('blue') && c.includes('red'),
+          3000,
+          (err) => {
+            if (err) {
+              cleanup();
+              return done(err);
+            }
+            setTimeout(() => {
+              fs.writeFileSync(path.join(tmpDir, '_colors.less'), '.mixin() { color: green; }');
+              waitForFileContent(
+                path.join(outDir, 'homepage.css'),
+                (c) => c.includes('green'),
+                5000,
+                (err2) => {
+                  try {
+                    if (err2) throw err2;
+                    assert.ok(
+                      !fs.existsSync(path.join(outDir, '_theme.css')) && !fs.existsSync(path.join(outDir, '_colors.css')),
+                      'hidden partials must never produce their own standalone output'
+                    );
+                    cleanup();
+                    done();
+                  } catch (e) {
+                    cleanup();
+                    done(e);
+                  }
+                }
+              );
+            }, 100);
+          }
+        );
+      });
     });
     describe('makeWatchHandler()', function () {
       let originalCompileCSS;
@@ -677,6 +744,63 @@ describe('lessWatchCompilerUtils Module API', function () {
         const fileimports = { '/a/main.less': ['partial.less'] };
         handler(changedFile, { nlink: 1 }, {}, fileimports);
         assert.deepStrictEqual(calls, ['compiled:/a/main.less', 'onCompile-for-change:' + changedFile]);
+      });
+
+      it('recompiles every ancestor in a multi-level @import chain, not just the direct importer (issue #59)', function () {
+        const calls = [];
+        lessWatchCompilerUtils.compileCSS = (file) => {
+          calls.push('compiled:' + file);
+          return { outputFilePath: '"' + file + '.css"' };
+        };
+        const handler = lessWatchCompilerUtils.makeWatchHandler(undefined, {
+          onImportCompile: (importingFile, changedFile) => calls.push('onImportCompile:' + importingFile + '<-' + changedFile)
+        });
+        // homepage.less -> theme.less -> colors.less
+        const changedFile = path.normalize('/a/colors.less');
+        const fileimports = {
+          '/a/homepage.less': ['theme.less'],
+          '/a/theme.less': ['colors.less']
+        };
+        handler(changedFile, { nlink: 1 }, {}, fileimports);
+        assert.deepStrictEqual(
+          calls.sort(),
+          [
+            'compiled:' + path.normalize('/a/theme.less'),
+            'compiled:' + path.normalize('/a/homepage.less'),
+            'onImportCompile:' + path.normalize('/a/theme.less') + '<-' + changedFile,
+            'onImportCompile:' + path.normalize('/a/homepage.less') + '<-' + changedFile
+          ].sort()
+        );
+      });
+
+      it('does not loop forever on a circular @import chain', function () {
+        const calls = [];
+        lessWatchCompilerUtils.compileCSS = (file) => {
+          calls.push('compiled:' + file);
+          return { outputFilePath: '"' + file + '.css"' };
+        };
+        const handler = lessWatchCompilerUtils.makeWatchHandler(undefined, {
+          onImportCompile: (importingFile, changedFile) => calls.push('onImportCompile:' + importingFile + '<-' + changedFile)
+        });
+        // a.less <-> b.less import each other: since each one is a genuine
+        // (transitive, via the cycle) ancestor of the other, editing b.less
+        // legitimately recompiles both exactly once each -- the point of
+        // this test is that the walk terminates rather than looping forever
+        // chasing the cycle, not that only one side gets recompiled.
+        const fileimports = {
+          '/a/a.less': ['b.less'],
+          '/a/b.less': ['a.less']
+        };
+        handler(path.normalize('/a/b.less'), { nlink: 1 }, {}, fileimports);
+        assert.deepStrictEqual(
+          calls.sort(),
+          [
+            'compiled:' + path.normalize('/a/a.less'),
+            'compiled:' + path.normalize('/a/b.less'),
+            'onImportCompile:' + path.normalize('/a/a.less') + '<-' + path.normalize('/a/b.less'),
+            'onImportCompile:' + path.normalize('/a/b.less') + '<-' + path.normalize('/a/b.less')
+          ].sort()
+        );
       });
     });
     describe('compileCSS()', function () {

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -656,6 +656,76 @@ describe('lessWatchCompilerUtils Module API', function () {
           }
         );
       });
+
+      it('never chases or produces standalone output for a non-.less @import target (issue #59 review follow-up)', function (done) {
+        // main.less -> reset.css -> fonts.css. Less doesn't inline a plain
+        // `@import "x.css"` by default (it stays a literal @import url(...)
+        // reference in the output), so following such a target's own
+        // imports for recompile purposes is both pointless and, by treating
+        // it as its own watchable/compilable entry, wrong: it must never
+        // produce a standalone .css output of its own, and editing
+        // something *it* imports must not propagate at all.
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-live-css-import-'));
+        const outDir = path.join(tmpDir, 'css');
+        fs.mkdirSync(outDir);
+        fs.writeFileSync(path.join(tmpDir, 'main.less'), '@import "reset.css";\n.a { color: red; }');
+        fs.writeFileSync(path.join(tmpDir, 'reset.css'), '@import "fonts.css";');
+        fs.writeFileSync(path.join(tmpDir, 'fonts.css'), '/* fonts */');
+
+        lessWatchCompilerUtils.config = { watchFolder: tmpDir, outputFolder: outDir };
+
+        function cleanup() {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+        }
+
+        lessWatchCompilerUtils.watchTree(
+          tmpDir,
+          { interval: 30, filter: lessWatchCompilerUtils.filterFiles },
+          lessWatchCompilerUtils.makeWatchHandler(undefined, {}),
+          function (f) {
+            lessWatchCompilerUtils.compileCSS(f);
+          }
+        );
+
+        waitForFileContent(
+          path.join(outDir, 'main.css'),
+          (c) => c.includes('red'),
+          3000,
+          (err) => {
+            if (err) {
+              cleanup();
+              return done(err);
+            }
+            setTimeout(() => {
+              fs.writeFileSync(path.join(tmpDir, 'fonts.css'), '/* changed */');
+              // Give the (if unguarded) chase through reset.css a dedicated
+              // window to prove itself before a control file's own compile
+              // could otherwise mask a race.
+              setTimeout(() => {
+                // A control file, started only now, proves the watcher is
+                // still alive and reacting normally.
+                fs.writeFileSync(path.join(tmpDir, 'control.less'), '.z { color: green; }');
+                waitForFileContent(
+                  path.join(outDir, 'control.css'),
+                  (c) => c.includes('green'),
+                  5000,
+                  (err2) => {
+                    try {
+                      if (err2) throw err2;
+                      assert.ok(!fs.existsSync(path.join(outDir, 'reset.css')), 'a non-.less @import target must never produce its own standalone output');
+                      cleanup();
+                      done();
+                    } catch (e) {
+                      cleanup();
+                      done(e);
+                    }
+                  }
+                );
+              }, 500);
+            }, 100);
+          }
+        );
+      });
     });
     describe('makeWatchHandler()', function () {
       let originalCompileCSS;


### PR DESCRIPTION
## **User description**
Fixes #59

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:

Issue #59 ("Handle transitive dependencies imports in less files", e.g. `homepage.less` imports `theme.less` imports `colors.less`) turned out to be two compounding bugs, not one:

1. **`fileWatcher()`'s @import-chasing loop never populated the import target's own import list.** It registered a bare `setupWatcher()` call for a newly-discovered `@import` target and manually deduped it into `filelistArr`, but never called `findLessImportsInFile()` on it. Depending on directory-walk discovery order, this could pre-empt the separate top-level `fileWatcher()` call (from `watchTree()`'s walk-result loop) that would otherwise have populated it — via the shared dedup guard — permanently leaving that file's entry in `fileimportlist` empty. Fixed by recursing through `fileWatcher()` itself instead of calling `setupWatcher()` directly, so a target's own imports are always recorded regardless of discovery order.
2. **`setupWatcher()`'s per-file change callback applied the hidden-file/extension filter *before* ever invoking `watchCallback`.** This silently swallowed changes to any hidden `_partial.less` file — the conventional naming for an @import-only file that's never meant to be compiled standalone — at *any* hop count, since the change notification never fired at all. `compileCSS()` already independently skips producing standalone output for hidden files, which is the correct place for that guard; the redundant, overly-broad one in `setupWatcher()` is removed.
3. **`makeWatchHandler()` only checked one hop of the import graph.** Even with (1) and (2) fixed, it only recompiled the *direct* importer of a changed file, not further ancestors. Rewrote the "who imports this" search as a BFS over the reverse-import relation so every ancestor — direct and transitive — gets recompiled, with a `visited` set to terminate safely on circular imports.

In practice, (2) was the most impactful: since real-world LESS projects almost universally name @import-only partials with a leading underscore, editing *any* partial silently failed to trigger a rebuild at all before this fix, regardless of import depth.

Test plan:
- [x] `makeWatchHandler()` unit tests: a 3-level chain (`homepage.less -> theme.less -> colors.less`) recompiles both ancestors, and a circular `a.less <-> b.less` import terminates correctly (recompiling both exactly once, not looping forever).
- [x] Live-watch end-to-end test: `homepage.less -> _theme.less -> _colors.less` (both intermediates hidden, the realistic real-world pattern) — editing `_colors.less` correctly updates `homepage.css`, and no `_theme.css`/`_colors.css` output is ever produced.
- [x] All four new/changed assertions verified via git-stash toggle to genuinely fail without the fix and pass with it.
- [x] Manual CLI smoke tests reproducing the original issue (non-hidden 2-hop chain, hidden 1-hop chain via both `_` and `.` prefixes, and the full realistic 2-hop hidden-partial chain) — all confirmed broken before the fix and fixed after.
- [x] Full suite (168 tests), lint, typecheck, and coverage all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
**Recompile all files that depend on a changed Less import**

### What Changed
- Editing a nested imported file now recompiles every file above it in the import chain, not just the nearest parent
- Changes to hidden partial files like `_theme.less` are now detected and trigger the right rebuilds
- Circular import chains stop safely instead of looping forever

### Impact
`✅ Fewer missed Less rebuilds`
`✅ Reliable updates for nested @import chains`
`✅ Safer handling of circular imports`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
