### PR TITLE
fix(#213): don't exit(1) mid-write when one --run-once compile fails

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -277,7 +277,16 @@ const lessWatchCompilerUtilsModule = {
         })
         .catch((error: Error & { line?: number; column?: number; filename?: string; extract?: string[] }) => {
           console.log(lessWatchCompilerUtilsModule.formatLessError(error));
-          if (config.runOnce) process.exit(1);
+          // Under --run-once, many files compile concurrently (none of these
+          // promises are awaited by the caller). process.exit(1) would kill
+          // the process immediately, mid-write, for any other in-flight
+          // renderLess() call -- fs.promises.writeFile() doesn't get to
+          // finish, leaving a truncated .css/.map file on disk for a file
+          // that would otherwise have compiled successfully (issue #213).
+          // Setting exitCode instead lets Node exit on its own once every
+          // pending compile actually finishes, preserving the "run-once
+          // with a compile error exits non-zero" contract without the race.
+          if (config.runOnce) process.exitCode = 1;
         });
     }
 

--- a/test/characterization.js
+++ b/test/characterization.js
@@ -214,6 +214,47 @@ describe('Characterization: exit codes', function () {
       'a missing main file must abort with a non-zero exit code'
     );
   });
+
+  it('still finishes writing every other file when one file fails to compile (issue #213)', () => {
+    // compileCSS() kicks off renderLess() for every discovered file without
+    // awaiting it, so under --run-once many files compile concurrently. If
+    // the failing file's error surfaces before the others' async I/O
+    // completes, calling process.exit(1) immediately (rather than setting
+    // process.exitCode and letting the event loop drain) can kill the
+    // process mid-write, losing or truncating output for files that would
+    // otherwise have compiled successfully.
+    const os = require('os');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-issue213-'));
+    const lessDir = path.join(tmpDir, 'less');
+    const cssDir = path.join(tmpDir, 'css');
+    fs.mkdirSync(lessDir);
+    const validCount = 60;
+    for (let i = 1; i <= validCount; i++) {
+      let content = '.sel-' + i + ' {\n';
+      for (let j = 1; j <= 40; j++) content += '  prop-' + j + ': value-' + j + ';\n';
+      content += '}\n';
+      fs.writeFileSync(path.join(lessDir, 'file' + i + '.less'), content);
+    }
+    fs.writeFileSync(path.join(lessDir, 'broken.less'), '.broken { color: @undefined-variable; }');
+
+    let threw = false;
+    try {
+      execSync(`node ${cliPath} --run-once ${lessDir} ${cssDir}`, { stdio: 'pipe' });
+    } catch (err) {
+      threw = true;
+      assert.notEqual(err.status, 0, 'a compile failure among many files must still exit non-zero');
+    }
+    assert.ok(threw, 'expected a non-zero exit');
+
+    const produced = fs.existsSync(cssDir) ? fs.readdirSync(cssDir).filter((f) => f.endsWith('.css')) : [];
+    assert.equal(produced.length, validCount, 'every file that would have compiled successfully must still be written');
+    for (const f of produced) {
+      const content = fs.readFileSync(path.join(cssDir, f), 'utf8');
+      assert.ok(content.trim().endsWith('}'), f + ' was truncated mid-write: ' + JSON.stringify(content));
+    }
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });
 
 describe('--init scaffolding', function () {

--- a/test/characterization.js
+++ b/test/characterization.js
@@ -5,7 +5,7 @@
 const assert = require('assert'),
   path = require('path'),
   fs = require('fs'),
-  { execSync, spawn } = require('child_process'),
+  { execSync, execFileSync, spawn } = require('child_process'),
   cwd = process.cwd(),
   outDir = path.join(cwd, 'test', 'css'),
   cliPath = path.resolve('dist/less-watch-compiler.js');
@@ -239,7 +239,12 @@ describe('Characterization: exit codes', function () {
 
     let threw = false;
     try {
-      execSync(`node ${cliPath} --run-once ${lessDir} ${cssDir}`, { stdio: 'pipe' });
+      // execFileSync (args as an array, no shell) rather than execSync with
+      // an interpolated string: lessDir/cssDir are built from os.tmpdir(),
+      // which isn't a literal, so a shell string is both unnecessary and
+      // fragile (breaks on a path containing a space, and is the shape
+      // CodeQL flags as command construction from an uncontrolled value).
+      execFileSync(process.execPath, [cliPath, '--run-once', lessDir, cssDir], { stdio: 'pipe' });
     } catch (err) {
       threw = true;
       assert.notEqual(err.status, 0, 'a compile failure among many files must still exit non-zero');


### PR DESCRIPTION
## **User description**
Fixes #213

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:

`compileCSS()` kicks off `renderLess()` for every discovered file without awaiting it, so under `--run-once` many files compile concurrently. When one file's compile failed, the `.catch()` handler called `process.exit(1)` immediately — killing the process mid-write for every other in-flight `renderLess()` call, before `fs.promises.writeFile()` had a chance to finish.

Reproduced this directly: 60 valid `.less` files plus 1 broken one, run through `--run-once`. The broken file's error (an undefined-variable reference, which fails during `less.render()` itself with no I/O involved) surfaced before any of the other 60 files' async `readFile`/`mkdir`/`writeFile` calls completed, so `process.exit(1)` discarded **all 60** valid outputs, not just the failing one — reproduced consistently across 5 repeated runs (0/60 files written each time).

Fix: set `process.exitCode = 1` instead of calling `process.exit(1)`, and let the event loop drain naturally. `setupWatcher()` already returns immediately under `--run-once` (no `fs.watchFile` registered), so nothing else keeps the process alive once every pending compile actually finishes — Node exits on its own with the exit code that was set. This preserves the existing "run-once with a compile error exits non-zero" contract without the mid-write race.

Test plan:
- [x] New regression test: 60 valid files + 1 broken file under `--run-once`, asserting (a) the process still exits non-zero and (b) every valid file's output exists and is complete (not truncated).
- [x] Verified via git-stash toggle: fails without the fix (0/60 files produced, matching the manual repro exactly) and passes with it (60/60 files produced, complete, every run).
- [x] Manual repro across 5 repeated runs before/after, both with the CLI directly and via the new automated test.
- [x] Full suite (170 tests), lint, typecheck, and coverage all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
**Keep `--run-once` from stopping other files mid-write when one compile fails**

### What Changed
- When one file fails to compile in `--run-once` mode, the process now finishes writing the other files instead of stopping immediately
- A compile failure still makes the command exit with a non-zero status
- Added a regression test that covers many successful files plus one broken file, and checks that all successful outputs are written completely

### Impact
`✅ No lost CSS from one broken file`
`✅ Fewer truncated output files`
`✅ Reliable non-zero exit on compile errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
