### PR TITLE
Add --minified CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ less-watch-compiler
     --config <file>                                                          Custom configuration file path. (default: "less-watch-compiler.config.json")
     --run-once                                                               Run the compiler once without waiting for additional changes.
     --include-hidden                                                         Don't ignore files beginning with a '.' or a '_'
+    --minified                                                               Less.js Option: Produce compressed output with a '.min.css' extension.
     --enable-js                                                              Less.js Option: To enable inline JavaScript in less files.
     --source-map                                                             Less.js Option: To generate source map for css files.
     --plugins <plugin-a>,<plugin-b>                                          Less.js Option: To specify plugins separated by commas.
@@ -167,7 +168,7 @@ less-watch-compiler
 
 ## Please note:
 
-- By default, "minified" is turned off (full, uncompressed CSS output). Set `"minified":true` in the config file to compress output and write `.min.css` files instead.
+- By default, "minified" is turned off (full, uncompressed CSS output). Set `"minified":true` in the config file, or pass `--minified` on the CLI, to compress output and write `.min.css` files instead.
 - By default, "sourceMap" is turned off. You can generating sourcemap to true by adding `"sourceMap":true` in the config file.
 - By default, this script only compiles files with `.less` extension. More file extensions can be added by modifying the `allowedExtensions` array in `config.json`.
 - Files that start with underscores `_style.css` or period `.style.css` are ignored. This behavior can be changed by adding `"includeHidden:true` in the config file.

--- a/src/less-watch-compiler.ts
+++ b/src/less-watch-compiler.ts
@@ -48,6 +48,7 @@ program
   .option('--banner', "Prepend a 'generated file, do not edit' comment to compiled CSS.")
   .option('--banner-text <text>', 'Custom banner text to use instead of the default message. Implies --banner.')
   // Less Options
+  .option('--minified', "Less.js Option: Produce compressed output with a '.min.css' extension.")
   .option('--enable-js', 'Less.js Option: To enable inline JavaScript in less files.')
   .option('--source-map', 'Less.js Option: To generate source map for css files.')
   .option('--plugins <plugin-a>,<plugin-b>', 'Less.js Option: To specify plugins separated by commas.')
@@ -64,6 +65,7 @@ const programOption = program.opts<{
   config?: string;
   runOnce?: boolean;
   includeHidden?: boolean;
+  minified?: boolean;
   enableJs?: boolean;
   sourceMap?: boolean;
   plugins?: string;
@@ -127,6 +129,7 @@ function init(): void {
   if (args[2]) lessWatchCompilerUtils.config.mainFile = args[2];
   if (programOption.mainFile) lessWatchCompilerUtils.config.mainFile = programOption.mainFile;
   if (programOption.sourceMap !== undefined) lessWatchCompilerUtils.config.sourceMap = programOption.sourceMap;
+  if (programOption.minified !== undefined) lessWatchCompilerUtils.config.minified = programOption.minified;
   if (programOption.plugins) lessWatchCompilerUtils.config.plugins = programOption.plugins;
   if (programOption.runOnce !== undefined) lessWatchCompilerUtils.config.runOnce = programOption.runOnce;
   if (programOption.includeHidden !== undefined) lessWatchCompilerUtils.config.includeHidden = programOption.includeHidden;

--- a/test/characterization.js
+++ b/test/characterization.js
@@ -64,10 +64,21 @@ describe('Characterization: golden-file output parity', function () {
     });
   });
 
-  describe('minified config option', function () {
+  describe('minified option (config key and --minified CLI flag, issue #46)', function () {
     it('produces a byte-identical .min.css when the config file sets minified: true', () => {
       resetOutDir();
       cli('--config', 'test/examples/with-minified/less-watch-compiler.config.json');
+      const produced = fs.readFileSync(path.join(outDir, 'with-minified.min.css'));
+      const golden = fs.readFileSync(path.join(cwd, 'test', 'examples', 'with-minified', 'css', 'with-minified.min.css'));
+      assert.ok(produced.equals(golden));
+      resetOutDir();
+    });
+
+    it('produces the same byte-identical .min.css via the --minified CLI flag, with no config file', () => {
+      // --minified was documented as a config-file-only key with no CLI flag
+      // exposing it; this is the flag-based equivalent of the test above.
+      resetOutDir();
+      cli('--run-once', '--minified', 'test/examples/with-minified/less', outDir);
       const produced = fs.readFileSync(path.join(outDir, 'with-minified.min.css'));
       const golden = fs.readFileSync(path.join(cwd, 'test', 'examples', 'with-minified', 'css', 'with-minified.min.css'));
       assert.ok(produced.equals(golden));


### PR DESCRIPTION
## **User description**
Partially addresses #46 (does not close it — see below)

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
- Adds `--minified` as a CLI flag, mirroring the existing `--enable-js`/`--source-map` flags. `minified` has been a config-file-only key since the beginning — there was no way to turn it on from the command line, which the repo owner flagged as an aside in the #46 discussion back in 2017 ("Not to mention that the `--minified` flag is missing"). The docs even already referenced `--minified` as a cache-invalidating option before this PR, despite the flag not existing yet.

**Not addressed here:** #46's original, literal ask was a fully custom output filename (e.g. `main.min.css` from `main.less`, decoupled from the minified transform). That's a separate, larger design question — a single custom name only makes unambiguous sense in single-`mainFile` mode, since a recursive multi-file watch has many inputs mapping to many outputs with no single name to override. Leaving `--minified` as this PR's only scope and leaving #46 open for that part; happy to follow up once the shape of that is settled (it likely also interacts with #108's "multiple main files" discussion).

Test plan:
- [x] Golden-file test: `--minified` via the CLI produces byte-identical output to the existing config-file-based `minified: true` golden fixture.
- [x] Verified via git-stash toggle that the new CLI-flag test fails without the change (`unknown option '--minified'`) and passes with it; the existing config-file test is untouched and still passes independently.
- [x] Manual CLI smoke test.
- [x] Full suite (182 tests), lint, typecheck, and coverage all pass.


---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
**Add a CLI flag for minified output**

### What Changed
- You can now turn on minified output from the command line with `--minified`, not just through the config file
- The CLI help and README now mention `--minified` and explain that it writes `.min.css` files
- Added a test that confirms the CLI flag produces the same minified output as the existing config setting

### Impact
`✅ Minified builds from the command line`
`✅ Fewer config-only setup steps`
`✅ Clearer docs for compressed output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
