### PR TITLE
Fix release workflow: NODE_AUTH_TOKEN unresolved in .npmrc breaks publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,14 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      # actions/setup-node's registry-url writes .npmrc referencing
+      # ${NODE_AUTH_TOKEN}; it must exist (even empty) or npm/yarn fail
+      # with "Failed to replace env in config" on the very first command
+      # that reads .npmrc. Leaving it empty makes npm fall through to
+      # OIDC trusted publishing (id-token: write above) instead of a
+      # static token.
+      NODE_AUTH_TOKEN: ''
     steps:
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
## **User description**
Fixes the release workflow error:

```
error Error: Failed to replace env in config: ${NODE_AUTH_TOKEN}
```

**Root cause:** `actions/setup-node`'s `registry-url` input writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. The `release` job never set that env var anywhere, so the very first npm/yarn command that reads `.npmrc` (as early as the "Install deps" step) fails trying to resolve the placeholder — the job never even reaches the publish step.

**Fix:** set `NODE_AUTH_TOKEN: ''` at the job level. An empty string still satisfies the substitution (the var just needs to exist), but isn't used as a real bearer token, so `npm publish --provenance` falls through to OIDC trusted publishing via the existing `permissions: id-token: write`. This matches the currently-documented pattern for npm trusted publishing from GitHub Actions.

**Note:** this assumes the package already has a Trusted Publisher configured on npmjs.com for this repo/workflow (Package Settings → Trusted Publisher). If that hasn't been set up yet, this fix clears the immediate config error but publish will still need that one-time npmjs.com configuration to succeed.

This workflow only triggers on `v*` tag pushes, so it can't be exercised by this PR's own CI — verified by inspection against the current npm trusted-publishing docs/guidance.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jBxLoD5eHgQzSLtDgezQ6)_


___

## **CodeAnt-AI Description**
Fix the release job so npm can read the publish settings and continue to publishing

### What Changed
- The release workflow now sets `NODE_AUTH_TOKEN` to an empty value so npm and yarn can read the package registry settings without failing on the first install step
- This removes the release error that blocked the job before it reached publish
- Publishing still uses GitHub’s trusted publishing path instead of a stored token

### Impact
`✅ Release jobs no longer fail during dependency install`
`✅ Fewer blocked npm publishes from tag releases`
`✅ Cleaner trusted publishing for package releases`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
