### PR TITLE
Potential fix for code scanning alert no. 10: Shell command built from environment values

### DIFF
--- a/test/characterization.js
+++ b/test/characterization.js
@@ -327,13 +327,13 @@ describe('--init scaffolding', function () {
 
   it('creates a config template and exits 0; refuses to overwrite an existing one', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-init-'));
-    execSync(`node ${cliPath} --init`, { cwd: tmpDir, stdio: 'pipe' });
+    execFileSync('node', [cliPath, '--init'], { cwd: tmpDir, stdio: 'pipe' });
     const configFile = path.join(tmpDir, 'less-watch-compiler.config.json');
     assert.ok(fs.existsSync(configFile), 'config template must be created');
     const parsed = JSON.parse(fs.readFileSync(configFile, 'utf8'));
     assert.equal(parsed.watchFolder, 'less');
     assert.throws(
-      () => execSync(`node ${cliPath} --init`, { cwd: tmpDir, stdio: 'pipe' }),
+      () => execFileSync('node', [cliPath, '--init'], { cwd: tmpDir, stdio: 'pipe' }),
       (err) => err.status !== 0,
       'a second --init must not overwrite the existing config'
     );


### PR DESCRIPTION
Potential fix for [https://github.com/jonycheung/deadsimple-less-watch-compiler/security/code-scanning/10](https://github.com/jonycheung/deadsimple-less-watch-compiler/security/code-scanning/10)

Use `execFileSync` (or `spawnSync`) with explicit command and argument array instead of `execSync` with an interpolated shell string.

Best fix here (without changing behavior): in `test/characterization.js`, replace the two `execSync(\`node ${cliPath} --init\`, ...)` calls in the `--init scaffolding` test with `execFileSync('node', [cliPath, '--init'], ...)`. This preserves `cwd`/`stdio` behavior and avoids shell parsing of `cliPath`. No new imports are needed because `execFileSync` is already imported on line 8.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
