### PR TITLE
feat: add rebuildAllOn option to force a full recompile (#241)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ less-watch-compiler
   "cache": false,
   "cachePath": "<optional_cache_file_path>",
   "exclude": "<optional_regex_pattern>",
-  "banner": false
+  "banner": false,
+  "rebuildAllOn": ["<optional_regex_pattern>"]
 }
 ```
 
@@ -165,6 +166,7 @@ less-watch-compiler
     --exclude <pattern>                                                     Additional regex pattern for paths to never watch or compile, e.g. '--exclude dist'. node_modules and .git are always excluded.
     --banner                                                                 Prepend a 'generated file, do not edit' comment to compiled CSS.
     --banner-text <text>                                                     Custom banner text to use instead of the default message. Implies --banner.
+    --rebuild-all-on <pattern-a>,<pattern-b>                                 Regex pattern(s), comma-separated, for shared/global partials, e.g. '--rebuild-all-on ^shared/'. A change to a matching file recompiles every tracked .less file instead of just its importers. Off by default.
 
 ## Please note:
 
@@ -175,6 +177,7 @@ less-watch-compiler
 - `node_modules` and `.git` are always excluded from the watch and compile, no flag needed.
 - `--exclude <pattern>` (or `"exclude"` in the config file) adds an additional regex pattern for files or directories to keep out of the watch and compile entirely — it doesn't replace the `node_modules`/`.git` default, it adds to it. Unlike `allowedExtensions`, which only narrows which files count as compilable, `exclude` also stops the walk from descending into matching directories at all (e.g. `--exclude dist`). An invalid regex pattern exits with an error.
 - `--banner` (or `"banner": true` in the config file) prepends a "generated file, don't edit" comment to every compiled CSS file; off by default. `--banner-text <text>` (or a string value for `"banner"` in the config file) uses custom text instead of the default message — a multi-line string is wrapped as a `/* ... */` block comment. Works correctly together with `--source-map` (both the plain and inline forms): the map is adjusted so it still resolves to the right line in the source `.less` file despite the banner shifting everything below it down.
+- `--rebuild-all-on <pattern>` (or `"rebuildAllOn": ["<pattern>", ...]` in the config file) is for shared/global partials (variables, mixins, tokens) imported by many independent entry points, where tracking exactly who imports the changed file can miss some of them. When a changed file matches any of these regex patterns, every currently tracked `.less` file is recompiled instead of just its importers. Off by default. Multiple patterns are comma-separated on the CLI, same convention as `--plugins`/`--less-args`. Patterns are regexes (not globs), the same convention as `--exclude` — e.g. `--rebuild-all-on ^shared/` matches any path starting with `shared/`. An invalid pattern exits with an error. If `--main-file`/`mainFile` is also set, the main file still always wins (it's compiled regardless of what changed); otherwise a `rebuildAllOn` match takes priority over the normal import-graph handling.
 - When `--run-once` used, compilation will fail on first error
 
 ## Incremental compilation for CI
@@ -212,7 +215,7 @@ watch(
 );
 ```
 
-`compileFile(inputFilePath, outputFolder, options?)` and `watch(watchFolder, outputFolder, options?, listeners?)` accept the same options as the config file (`minified`, `sourceMap`, `enableJs`, `lessArgs`, `plugins`, `cache`, `cachePath`, `banner`, and for `watch` also `mainFile`, `includeHidden`, `allowedExtensions`, `exclude`). `compileFile()` honors `cache`/`cachePath` directly (see [Incremental compilation for CI](#incremental-compilation-for-ci) above); `watch()` accepts them for config-shape parity but doesn't use them, since a live watch session always recompiles on a real change. `watch()` always excludes `node_modules` and `.git`; `exclude` adds to that rather than replacing it, and an invalid pattern throws synchronously. TypeScript definitions are bundled. Note that the compiler keeps its configuration in module-level state, so one configuration per process applies at a time.
+`compileFile(inputFilePath, outputFolder, options?)` and `watch(watchFolder, outputFolder, options?, listeners?)` accept the same options as the config file (`minified`, `sourceMap`, `enableJs`, `lessArgs`, `plugins`, `cache`, `cachePath`, `banner`, and for `watch` also `mainFile`, `includeHidden`, `allowedExtensions`, `exclude`, `rebuildAllOn`). `compileFile()` honors `cache`/`cachePath` directly (see [Incremental compilation for CI](#incremental-compilation-for-ci) above); `watch()` accepts them for config-shape parity but doesn't use them, since a live watch session always recompiles on a real change. `watch()` always excludes `node_modules` and `.git`; `exclude` adds to that rather than replacing it, and an invalid pattern throws synchronously. `rebuildAllOn` is an array of regex pattern strings (off by default); an invalid pattern throws synchronously, same as `exclude`. TypeScript definitions are bundled. Note that the compiler keeps its configuration in module-level state, so one configuration per process applies at a time.
 
 ### Using the source files
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,15 @@ export interface WatchOptions extends CompileOptions {
    * that rather than replacing it.
    */
   exclude?: string;
+  /**
+   * Regex pattern strings (same convention as `exclude`) identifying
+   * shared/global partials, e.g. ['^shared/']. A change to a file matching
+   * any of these recompiles every currently tracked .less file instead of
+   * just its importers -- for partials imported by many independent entry
+   * points, where per-parent import tracking can miss some of them. Off
+   * (undefined) by default.
+   */
+  rebuildAllOn?: string[];
 }
 
 export interface WatchListeners {
@@ -129,6 +138,13 @@ export function watch(watchFolder: string, outputFolder: string, options: WatchO
     throw new Error('Invalid exclude pattern ' + JSON.stringify(options.exclude) + ': ' + (err as Error).message, { cause: err });
   }
 
+  let rebuildAllOnPattern: RegExp | undefined;
+  try {
+    rebuildAllOnPattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(options.rebuildAllOn);
+  } catch (err) {
+    throw new Error('Invalid rebuildAllOn pattern ' + JSON.stringify(options.rebuildAllOn) + ': ' + (err as Error).message, { cause: err });
+  }
+
   lessWatchCompilerUtils.watchTree(
     resolvedWatchFolder,
     {
@@ -137,11 +153,15 @@ export function watch(watchFolder: string, outputFolder: string, options: WatchO
       filter: lessWatchCompilerUtils.filterFiles,
       exclude
     },
-    lessWatchCompilerUtils.makeWatchHandler(mainFilePath, {
-      onRemove: listeners.onRemove,
-      onCompile: listeners.onCompile ? (f, result) => listeners.onCompile!(f, result.outputFilePath) : undefined,
-      onImportCompile: listeners.onImportCompile ? (i, f, result) => listeners.onImportCompile!(i, f, result.outputFilePath) : undefined
-    }),
+    lessWatchCompilerUtils.makeWatchHandler(
+      mainFilePath,
+      {
+        onRemove: listeners.onRemove,
+        onCompile: listeners.onCompile ? (f, result) => listeners.onCompile!(f, result.outputFilePath) : undefined,
+        onImportCompile: listeners.onImportCompile ? (i, f, result) => listeners.onImportCompile!(i, f, result.outputFilePath) : undefined
+      },
+      rebuildAllOnPattern
+    ),
     function (f: string) {
       if (!mainFilePath || mainFilePath === f) {
         lessWatchCompilerUtils.compileCSS(f);

--- a/src/less-watch-compiler.ts
+++ b/src/less-watch-compiler.ts
@@ -17,6 +17,7 @@ import extend from 'extend';
 import { Command } from 'commander';
 import events from 'events';
 import lessWatchCompilerUtils = require('./lib/lessWatchCompilerUtils');
+import lessOptions = require('./lib/lessOptions');
 
 const packagejson = require('../package.json');
 
@@ -50,6 +51,10 @@ program
   )
   .option('--banner', "Prepend a 'generated file, do not edit' comment to compiled CSS.")
   .option('--banner-text <text>', 'Custom banner text to use instead of the default message. Implies --banner.')
+  .option(
+    '--rebuild-all-on <pattern-a>,<pattern-b>',
+    "Regex pattern(s), comma-separated, for shared/global partials, e.g. '--rebuild-all-on ^shared/'. A change to a matching file recompiles every tracked .less file instead of just its importers. Off by default."
+  )
   // Less Options
   .option('--minified', "Less.js Option: Produce compressed output with a '.min.css' extension.")
   .option('--enable-js', 'Less.js Option: To enable inline JavaScript in less files.')
@@ -78,6 +83,7 @@ const programOption = program.opts<{
   exclude?: string;
   banner?: boolean;
   bannerText?: string;
+  rebuildAllOn?: string;
 }>();
 
 if (programOption.init) {
@@ -141,6 +147,14 @@ function init(): void {
   if (programOption.cache !== undefined) lessWatchCompilerUtils.config.cache = programOption.cache;
   if (programOption.cachePath) lessWatchCompilerUtils.config.cachePath = programOption.cachePath;
   if (programOption.exclude) lessWatchCompilerUtils.config.exclude = programOption.exclude;
+  if (programOption.rebuildAllOn) {
+    // Comma-separated, same convention as --plugins/--less-args; splitTopLevelCommas
+    // keeps a pattern's own top-level parens intact (e.g. an alternation).
+    lessWatchCompilerUtils.config.rebuildAllOn = lessOptions
+      .splitTopLevelCommas(programOption.rebuildAllOn)
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern !== '');
+  }
   if (programOption.bannerText) lessWatchCompilerUtils.config.banner = programOption.bannerText;
   else if (programOption.banner !== undefined) lessWatchCompilerUtils.config.banner = programOption.banner;
 
@@ -173,6 +187,14 @@ function init(): void {
     process.exit(1);
   }
 
+  let rebuildAllOnPattern: RegExp | undefined;
+  try {
+    rebuildAllOnPattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(lessWatchCompilerUtils.config.rebuildAllOn);
+  } catch (err) {
+    console.log('Invalid --rebuild-all-on pattern ' + JSON.stringify(lessWatchCompilerUtils.config.rebuildAllOn) + ': ' + (err as Error).message);
+    process.exit(1);
+  }
+
   if (lessWatchCompilerUtils.config.runOnce === true) console.log('Running less-watch-compiler once.');
   else console.log('Watching directory for file changes.');
 
@@ -185,28 +207,32 @@ function init(): void {
       filter: lessWatchCompilerUtils.filterFiles,
       exclude
     },
-    lessWatchCompilerUtils.makeWatchHandler(mainFilePath, {
-      onRemove(f) {
-        console.log(f + ' was removed.');
+    lessWatchCompilerUtils.makeWatchHandler(
+      mainFilePath,
+      {
+        onRemove(f) {
+          console.log(f + ' was removed.');
+        },
+        onImportCompile(importingFile, changedFile, compileResult) {
+          console.log(
+            'The file: ' +
+              importingFile +
+              ' was changed because ' +
+              JSON.stringify(changedFile) +
+              ' is specified as an import.  Recompiling ' +
+              compileResult.outputFilePath +
+              ' at ' +
+              lessWatchCompilerUtils.getDateTime()
+          );
+        },
+        onCompile(f, compileResult) {
+          console.log(
+            'The file: ' + JSON.stringify(f) + ' was changed. Recompiling ' + compileResult.outputFilePath + ' at ' + lessWatchCompilerUtils.getDateTime()
+          );
+        }
       },
-      onImportCompile(importingFile, changedFile, compileResult) {
-        console.log(
-          'The file: ' +
-            importingFile +
-            ' was changed because ' +
-            JSON.stringify(changedFile) +
-            ' is specified as an import.  Recompiling ' +
-            compileResult.outputFilePath +
-            ' at ' +
-            lessWatchCompilerUtils.getDateTime()
-        );
-      },
-      onCompile(f, compileResult) {
-        console.log(
-          'The file: ' + JSON.stringify(f) + ' was changed. Recompiling ' + compileResult.outputFilePath + ' at ' + lessWatchCompilerUtils.getDateTime()
-        );
-      }
-    }),
+      rebuildAllOnPattern
+    ),
     // init function
     function (f) {
       if (!mainFilePath || mainFilePath === f) {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -56,6 +56,11 @@ interface LessWatchCompilerConfig {
   // custom banner text. Off by default -- prepending anything to existing
   // users' output is a behavior change, so it stays opt-in (issue #82).
   banner?: boolean | string;
+  // Regex pattern strings (same convention as `exclude`, not globs -- see
+  // resolveRebuildAllOnPatterns) identifying shared/global partials. A
+  // change to a file matching any of these recompiles every currently
+  // tracked .less file, not just its importers (issue #241). Off by default.
+  rebuildAllOn?: string[];
 }
 
 type WalkCompleteCallback = (err: NodeJS.ErrnoException | null, files: FilesMap | null) => void;
@@ -188,6 +193,18 @@ const lessWatchCompilerUtilsModule = {
    * API: recompiles every importing ancestor (direct or transitive) when a
    * changed file is someone's @import, otherwise compiles the main file
    * (when set) or the changed file.
+   *
+   * rebuildAllOnPattern (issue #241) covers shared/global partials that many
+   * independent entry points import: per-parent import-graph tracking can
+   * miss some of those entries (or is simply not the right model -- a
+   * change to a shared tokens file should rebuild *everything*, not just
+   * whatever this run happened to observe importing it). Precedence: a
+   * single mainFilePath still always wins (matching the "single main file
+   * always wins" rule above it -- if the caller only ever wants one file
+   * compiled, that shouldn't change just because the edited file also
+   * matches rebuildAllOn); otherwise a rebuildAllOn match takes priority
+   * over the normal import-graph handling, recompiling every currently
+   * tracked .less file instead of just the changed file's importers.
    */
   makeWatchHandler(
     mainFilePath: string | undefined,
@@ -195,7 +212,8 @@ const lessWatchCompilerUtilsModule = {
       onRemove?: (file: string) => void;
       onCompile?: (file: string, result: CompileResult) => void;
       onImportCompile?: (importingFile: string, changedFile: string, result: CompileResult) => void;
-    }
+    },
+    rebuildAllOnPattern?: RegExp
   ): WatchCallback {
     return function (f, curr, prev, fileimports) {
       if (typeof f === 'object' && prev === null && curr === null) {
@@ -208,6 +226,18 @@ const lessWatchCompilerUtilsModule = {
         // A single main file always wins, regardless of import relationships.
         const compileResult = lessWatchCompilerUtilsModule.compileCSS(mainFilePath);
         if (compileResult && notify.onCompile) notify.onCompile(f as string, compileResult);
+      } else if (rebuildAllOnPattern && rebuildAllOnPattern.test(f as string)) {
+        // The changed file is a shared/global partial: recompile every
+        // currently tracked .less file, not just those known to import it.
+        // fileimports is keyed by every watched path (including non-.less
+        // and hidden files); filterFiles (inverted -- it returns true to
+        // EXCLUDE) narrows that down to the same set compileCSS would
+        // otherwise be asked to compile one-by-one via the import graph.
+        for (const trackedFile in fileimports) {
+          if (lessWatchCompilerUtilsModule.filterFiles(trackedFile)) continue;
+          const compileResult = lessWatchCompilerUtilsModule.compileCSS(trackedFile);
+          if (compileResult && notify.onImportCompile) notify.onImportCompile(trackedFile, f as string, compileResult);
+        }
       } else {
         // Build a reverse import index once (imported path -> importers)
         // instead of rescanning the whole fileimports map on every BFS step
@@ -441,6 +471,37 @@ const lessWatchCompilerUtilsModule = {
       throw new Error('pattern is not safe from catastrophic backtracking (exceeds the allowed repetition/star-height limit)');
     }
     return new RegExp(`(?:${defaultExcludePattern.source})|(?:${userRegex.source})`);
+  },
+
+  /**
+   * Compile the user-supplied --rebuild-all-on / rebuildAllOn patterns into
+   * a single RegExp, or undefined when the option is unset (matching the
+   * "off by default" contract). Deliberately regex-pattern strings, the same
+   * convention as --exclude, rather than globs: this repo has no glob
+   * dependency today and Node's built-in path.matchesGlob() is still
+   * experimental (see its docs) as of the Node versions this package
+   * supports, so reusing the already-validated exclude-style regex
+   * convention avoids both a new dependency and relying on an experimental
+   * API, at the cost of the exact `"shared/**"` glob syntax from issue #241
+   * (a regex equivalent, e.g. `"^shared/"`, covers the same case). Each
+   * pattern is validated the same way resolveExcludePattern validates
+   * --exclude: it must be a syntactically valid regex and pass safe-regex2's
+   * catastrophic-backtracking check, since the change handler tests every
+   * changed file against it. Callers decide how to surface the throw (CLI
+   * exits, API throws).
+   */
+  resolveRebuildAllOnPatterns(userPatterns?: string[]): RegExp | undefined {
+    if (!userPatterns || userPatterns.length === 0) return undefined;
+    const sources = userPatterns.map((pattern) => {
+      const userRegex = new RegExp(pattern);
+      if (!safeRegex(userRegex)) {
+        throw new Error(
+          'pattern ' + JSON.stringify(pattern) + ' is not safe from catastrophic backtracking (exceeds the allowed repetition/star-height limit)'
+        );
+      }
+      return userRegex.source;
+    });
+    return new RegExp(sources.map((source) => `(?:${source})`).join('|'));
   },
 
   getDateTime(): string {

--- a/test/api.js
+++ b/test/api.js
@@ -74,6 +74,87 @@ describe('Programmatic API (require("less-watch-compiler"))', function () {
     assert.throws(() => api.watch('test/less', 'test/css', { mainFile: 'no-such-main.less', runOnce: true }), /no-such-main\.less does not exist/);
   });
 
+  it('watch() throws synchronously for an invalid rebuildAllOn pattern, instead of watching silently forever', function () {
+    assert.throws(
+      () => api.watch('test/less', 'test/css', { rebuildAllOn: ['('], runOnce: true }),
+      /Invalid rebuildAllOn pattern.*Unterminated group/
+    );
+  });
+
+  it('watch() with rebuildAllOn recompiles every tracked file when a matching shared partial changes, even files that do not import it (issue #241)', function (done) {
+    this.timeout(15000);
+    const os = require('os');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-api-rebuildallon-'));
+    const lessDir = path.join(tmpDir, 'less');
+    const watchOutDir = path.join(tmpDir, 'css');
+    const sharedDir = path.join(lessDir, 'shared');
+    fs.mkdirSync(sharedDir, { recursive: true });
+    fs.mkdirSync(watchOutDir, { recursive: true });
+    const sharedFile = path.join(sharedDir, 'tokens.less');
+    const aFile = path.join(lessDir, 'a.less');
+    const bFile = path.join(lessDir, 'b.less');
+    // Neither a.less nor b.less imports tokens.less at all -- a plain
+    // import-graph watch would never reconnect them to it.
+    fs.writeFileSync(sharedFile, '.shared { color: red; }');
+    fs.writeFileSync(aFile, '.a { color: green; }');
+    fs.writeFileSync(bFile, '.b { color: green; }');
+
+    function waitForContent(filePath, predicate, timeoutMs, cb) {
+      const start = Date.now();
+      (function poll() {
+        fs.readFile(filePath, 'utf8', (err, content) => {
+          if (!err && predicate(content)) return cb(null, content);
+          if (Date.now() - start > timeoutMs) return cb(new Error('timed out waiting for ' + filePath));
+          setTimeout(poll, 50);
+        });
+      })();
+    }
+
+    function cleanup() {
+      fs.unwatchFile(sharedFile);
+      fs.unwatchFile(aFile);
+      fs.unwatchFile(bFile);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    api.watch(lessDir, watchOutDir, { rebuildAllOn: ['shared'] });
+
+    const aOut = path.join(watchOutDir, 'a.css');
+    const bOut = path.join(watchOutDir, 'b.css');
+    const staleMarker = '/* stale marker */';
+
+    waitForContent(aOut, (c) => c.includes('green'), 5000, (err) => {
+      if (err) {
+        cleanup();
+        return done(err);
+      }
+      waitForContent(bOut, (c) => c.includes('green'), 5000, (err2) => {
+        if (err2) {
+          cleanup();
+          return done(err2);
+        }
+        // Overwrite both outputs with a stale marker, then edit only the
+        // shared partial -- if rebuildAllOn is doing its job, both get
+        // overwritten with fresh output again despite neither importing it.
+        fs.writeFileSync(aOut, staleMarker);
+        fs.writeFileSync(bOut, staleMarker);
+        fs.writeFileSync(sharedFile, '.shared { color: blue; }');
+        waitForContent(aOut, (c) => c !== staleMarker && c.includes('green'), 8000, (err3) => {
+          if (err3) {
+            cleanup();
+            return done(err3);
+          }
+          waitForContent(bOut, (c) => c !== staleMarker && c.includes('green'), 8000, (err4, finalContent) => {
+            cleanup();
+            if (err4) return done(err4);
+            assert.ok(finalContent.includes('green'));
+            done();
+          });
+        });
+      });
+    });
+  });
+
   it('watch() compiles on start and recompiles the output when a watched file is later edited', function (done) {
     this.timeout(15000);
     const os = require('os');

--- a/test/less-watch-compiler.js
+++ b/test/less-watch-compiler.js
@@ -117,6 +117,20 @@ describe('The CLI should', function () {
       });
     });
 
+    describe('--rebuild-all-on parameter', function () {
+      it('should still run-once normally (unaffected default behavior) when a valid pattern is given', () => {
+        // --run-once never exercises the watch change-handler branch that
+        // reads rebuildAllOn (it compiles every file once via the init
+        // callback), so this only proves the option is accepted end-to-end
+        // and doesn't break the option-off code path.
+        cli('--run-once', 'test/less', 'test/css', '--rebuild-all-on', '^shared/,^tokens/');
+      });
+
+      it('should exit non-zero for an invalid --rebuild-all-on pattern', () => {
+        assert.throws(() => cli('--run-once', 'test/less', 'test/css', '--rebuild-all-on', '('));
+      });
+    });
+
     describe('--less-args parameter', function () {
       const lessDir = cwd + '/test/examples/with-less-args/less',
         expectedCssDir = cwd + '/test/examples/with-less-args/css',

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -872,6 +872,85 @@ describe('lessWatchCompilerUtils Module API', function () {
           ].sort()
         );
       });
+
+      it('recompiles every tracked .less file when the changed file matches rebuildAllOnPattern, not just its importers (issue #241)', function () {
+        const calls = [];
+        lessWatchCompilerUtils.compileCSS = (file) => {
+          calls.push('compiled:' + file);
+          return { outputFilePath: '"' + file + '.css"' };
+        };
+        const rebuildAllOnPattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['^' + path.normalize('/shared/').replace(/\\/g, '\\\\')]);
+        const handler = lessWatchCompilerUtils.makeWatchHandler(
+          undefined,
+          {
+            onImportCompile: (importingFile, changedFile) => calls.push('onImportCompile:' + importingFile + '<-' + changedFile)
+          },
+          rebuildAllOnPattern
+        );
+        const changedFile = path.normalize('/shared/tokens.less');
+        // homepage.less does not import tokens.less at all -- a plain
+        // import-graph walk would never reach it, but rebuildAllOn must
+        // still recompile it since it's a currently tracked .less file.
+        const fileimports = {
+          '/homepage.less': [],
+          '/about.less': ['shared/tokens.less'],
+          '/shared/tokens.less': [],
+          '/shared/README.md': [] // not a .less file: filterFiles must exclude it
+        };
+        handler(changedFile, { nlink: 1 }, {}, fileimports);
+        assert.deepStrictEqual(
+          calls.sort(),
+          [
+            'compiled:/homepage.less',
+            'compiled:/about.less',
+            'compiled:' + changedFile,
+            'onImportCompile:/homepage.less<-' + changedFile,
+            'onImportCompile:/about.less<-' + changedFile,
+            'onImportCompile:' + changedFile + '<-' + changedFile
+          ].sort()
+        );
+      });
+
+      it('mainFile still wins over a rebuildAllOn match, matching the "single main file always wins" rule', function () {
+        const calls = [];
+        lessWatchCompilerUtils.compileCSS = (file) => {
+          calls.push('compiled:' + file);
+          return { outputFilePath: '"main.css"' };
+        };
+        const rebuildAllOnPattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['shared']);
+        const handler = lessWatchCompilerUtils.makeWatchHandler(
+          '/a/main.less',
+          {
+            onCompile: (f) => calls.push('onCompile:' + f),
+            onImportCompile: () => calls.push('onImportCompile')
+          },
+          rebuildAllOnPattern
+        );
+        const changedFile = path.normalize('/a/shared/tokens.less');
+        const fileimports = { '/a/main.less': [], '/a/shared/tokens.less': [] };
+        handler(changedFile, { nlink: 1 }, {}, fileimports);
+        assert.deepStrictEqual(calls, ['compiled:/a/main.less', 'onCompile:' + changedFile]);
+      });
+
+      it('falls back to normal import-graph handling when rebuildAllOnPattern is set but the changed file does not match it', function () {
+        const calls = [];
+        lessWatchCompilerUtils.compileCSS = (file) => {
+          calls.push('compiled:' + file);
+          return { outputFilePath: '"' + file + '.css"' };
+        };
+        const rebuildAllOnPattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['^' + path.normalize('/shared/').replace(/\\/g, '\\\\')]);
+        const handler = lessWatchCompilerUtils.makeWatchHandler(
+          undefined,
+          {
+            onImportCompile: (importingFile, changedFile) => calls.push('onImportCompile:' + importingFile + '<-' + changedFile)
+          },
+          rebuildAllOnPattern
+        );
+        const changedFile = path.normalize('/a/partial.less');
+        const fileimports = { '/a/main.less': ['partial.less'], '/unrelated.less': [] };
+        handler(changedFile, { nlink: 1 }, {}, fileimports);
+        assert.deepStrictEqual(calls, ['compiled:/a/main.less', 'onImportCompile:/a/main.less<-' + changedFile]);
+      });
     });
     describe('compileCSS()', function () {
       // reset config
@@ -1153,6 +1232,33 @@ describe('lessWatchCompilerUtils Module API', function () {
       });
       it('accepts an ordinary user pattern that safe-regex2 does not flag', function () {
         assert.doesNotThrow(() => lessWatchCompilerUtils.resolveExcludePattern('dist|build'));
+      });
+    });
+    describe('resolveRebuildAllOnPatterns()', function () {
+      it('resolveRebuildAllOnPatterns() function should be there', function () {
+        assert.equal('function', typeof lessWatchCompilerUtils.resolveRebuildAllOnPatterns);
+      });
+      it('returns undefined (off) when unset or given an empty array, unlike resolveExcludePattern which always returns a default pattern', function () {
+        assert.equal(lessWatchCompilerUtils.resolveRebuildAllOnPatterns(), undefined);
+        assert.equal(lessWatchCompilerUtils.resolveRebuildAllOnPatterns([]), undefined);
+      });
+      it('compiles a single pattern into a matching RegExp', function () {
+        const pattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['^shared/']);
+        assert.ok(pattern.test('shared/tokens.less'));
+        assert.ok(!pattern.test('page/tokens.less'));
+      });
+      it('combines multiple patterns so a match against any one of them is sufficient', function () {
+        const pattern = lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['^shared/', '^mixins/']);
+        assert.ok(pattern.test('shared/tokens.less'));
+        assert.ok(pattern.test('mixins/buttons.less'));
+        assert.ok(!pattern.test('page/tokens.less'));
+      });
+      it('throws a clean error referencing the offending pattern when it is not a valid regex', function () {
+        assert.throws(() => lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['[']), /Unterminated character class/);
+      });
+      it('rejects a pattern with catastrophic backtracking potential instead of accepting it silently', function () {
+        // Tested against every changed file, same reasoning as --exclude.
+        assert.throws(() => lessWatchCompilerUtils.resolveRebuildAllOnPatterns(['(x+x+)+y']), /catastrophic backtracking/);
       });
     });
     describe('getDateTime()', function () {


### PR DESCRIPTION
## **User description**
Fixes #241

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [x] Did you add update docs in the `README.md` file?

Changes proposed in this pull request:
- Add a `rebuildAllOn` config-file / programmatic-API option and a matching `--rebuild-all-on <pattern-a>,<pattern-b>` CLI flag: when a changed file matches any of these patterns, `makeWatchHandler()` recompiles **every currently tracked `.less` file**, not just the changed file's traced importers. Solves the "shared/global partial imported by many independent entry points" case from the issue, where per-parent import-graph tracking can legitimately miss some entries.
- New `resolveRebuildAllOnPatterns()` helper in `src/lib/lessWatchCompilerUtils.ts`, mirroring `resolveExcludePattern()`'s validation shape (via `safe-regex2`) but returning `undefined` when unset instead of a default pattern (there's nothing to default to — this feature is off unless configured).
- Wired through both public surfaces per this repo's CLAUDE.md: `WatchOptions.rebuildAllOn` in `src/index.ts`, `--rebuild-all-on` in `src/less-watch-compiler.ts` (comma-separated, same convention as `--plugins`/`--less-args`), and documented in all three README spots (config-file example, CLI flags table, programmatic API section).
- Not added to the `--init` scaffold, matching that scaffold's existing philosophy of only including the handful of most-common options (it doesn't include `exclude`, `mainFile`, `lessArgs`, or `banner` either).

**Glob vs. regex decision:** the issue's example (`"rebuildAllOn": ["shared/**"]`) is glob syntax, but this PR uses regex pattern strings instead (e.g. `"^shared/"`), the same convention `--exclude` already uses. Reasoning:
- This repo has zero glob dependencies today (`package.json` deps: commander, extend, less, safe-regex2 only), and adding one for a single option is disproportionate.
- Node's built-in `path.matchesGlob()` exists in the supported Node range (`>=22.12.0`) but is still documented as **Experimental (Stability 1.1)** — not something to build a public API option on without a fallback story.
- Reusing `--exclude`'s exact validated pattern (regex + `safe-regex2` catastrophic-backtracking guard) keeps the surface area minimal, requires no new glob-matching semantics to design/document/test, and stays consistent with an existing, already-understood convention in this codebase.
- The tradeoff: users write `"^shared/"` instead of `"shared/**"`. Documented clearly in the README and CLI help text.

**Precedence:** documented with a comment in `makeWatchHandler()` — a single `mainFile` still always wins (unchanged "single main file always wins" rule); otherwise a `rebuildAllOn` match takes priority over the normal import-graph walk.

**Tests added** (`test/lessWatchCompilerUtils.js`, `test/api.js`, `test/less-watch-compiler.js`):
- `resolveRebuildAllOnPatterns()`: off/undefined by default, single + multi-pattern matching, invalid-regex throw, catastrophic-backtracking rejection.
- `makeWatchHandler()`: a rebuildAllOn match recompiles every tracked file including ones that don't import the changed file at all; `mainFile` still wins over a match; falls back to normal import-graph handling on a non-match.
- `test/api.js`: `watch()` throws synchronously on an invalid pattern (same shape as the existing missing-`mainFile` throw test); an end-to-end real-`fs.watchFile` test proving two unrelated entry files both get recompiled when an unimported shared partial changes.
- `test/less-watch-compiler.js`: CLI accepts a valid `--rebuild-all-on` under `--run-once` without regressing default behavior; exits non-zero for an invalid pattern.

**Suggested semver bump: minor.** `rebuildAllOn` is a new, fully optional field (default `undefined`/off) on `WatchOptions` plus a new CLI flag — purely additive, zero behavior change for anyone not setting it, per this repo's CLAUDE.md semver guidance.

**Verification:**
- `yarn lint` — pass
- `yarn format:check` — pass
- `yarn typecheck` — pass
- `yarn test` — pass (195 passing)
- `yarn coverage` — pass, thresholds not regressed (statements 97.14/93, branches 87.52/80, functions 90.74/85, lines 97.14/93)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkzrDY12rHWVKFof1QveFQ)_


___

## **CodeAnt-AI Description**
Recompile all Less entry points when shared partials change

### What Changed
- Added `rebuildAllOn` configuration and API support for regex patterns that identify shared or global Less partials.
- Added the `--rebuild-all-on` CLI option with comma-separated patterns.
- When a matching file changes, all tracked `.less` files are recompiled instead of only known importers.
- Existing `mainFile` behavior remains unchanged and takes priority.
- Invalid or unsafe patterns now produce clear errors in the API and CLI.
- Added coverage for full rebuilds, pattern validation, CLI handling, and existing behavior.

### Impact
`✅ Fewer stale CSS files after shared partial changes`
`✅ Reliable rebuilds for independent Less entry points`
`✅ Clearer invalid-pattern errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
