### PR TITLE
fix(watcher): keep watching a .less file that is deleted and recreated

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -106,6 +106,17 @@ function forgetWatchedFile(f: string): void {
   delete fileimportlist[f];
 }
 
+// The allowed-extension half of filterFiles(), without its hidden-file half.
+// The two are fused in filterFiles() because the initial walk() wants both:
+// it is deciding which files to compile on sight, and a hidden file is not
+// one of them. Anywhere we're deciding what to *watch*, only the extension
+// check applies -- a hidden `_partial.less` still has to be followed, because
+// something else imports it and needs recompiling when it changes (issue #59).
+function hasAllowedExtension(filePath: string): boolean {
+  const allowedExtensions = lessWatchCompilerUtilsModule.config.allowedExtensions || defaultAllowedExtensions;
+  return allowedExtensions.indexOf(path.extname(filePath)) !== -1;
+}
+
 const lessWatchCompilerUtilsModule = {
   config: {} as LessWatchCompilerConfig,
 
@@ -573,14 +584,21 @@ const lessWatchCompilerUtilsModule = {
                 // never start being watched, the same way walk() already
                 // keeps the initial scan out of it entirely.
                 if (options.exclude && options.exclude.test(file)) return;
-                // The extension filter must only apply to files -- a new
+                // The extension check must only apply to files -- a new
                 // directory (e.g. one created after startup) never matches
-                // an allowed extension, so applying the filter to it too
-                // would skip watching it (and everything created inside it
-                // afterward) entirely. walk() already gets this right for
-                // the initial recursive scan; mirror it here for new
+                // an allowed extension, so applying it to directories too
+                // would skip watching them (and everything created inside
+                // them afterward) entirely. walk() already gets this right
+                // for the initial recursive scan; mirror it here for new
                 // directories discovered later by this readdir rescan.
-                if (!stat.isDirectory() && options.filter && options.filter(b)) return;
+                //
+                // Extension only, NOT options.filter: filterFiles() also
+                // rejects hidden files, and using it here meant a recreated
+                // `_partial.less` was never rediscovered, so nothing importing
+                // it recompiled again for the rest of the session. Watching a
+                // hidden file is correct -- compileCSS() is what declines to
+                // give it standalone output, and it still does.
+                if (!stat.isDirectory() && !hasAllowedExtension(b)) return;
                 fs.access(file, fs.constants.F_OK, (accessErr) => {
                   if (accessErr) {
                     console.log('Does not exist : ' + f);
@@ -655,8 +673,7 @@ const lessWatchCompilerUtilsModule = {
       // own. This must check extension only, NOT hidden-file status: a
       // hidden _partial.less is exactly the kind of target issue #59 needs
       // to keep following.
-      const importAllowedExtensions = lessWatchCompilerUtilsModule.config.allowedExtensions || defaultAllowedExtensions;
-      if (importAllowedExtensions.indexOf(path.extname(importPath)) === -1) continue;
+      if (!hasAllowedExtension(importPath)) continue;
       // Recurse via fileWatcher(), not a bare setupWatcher() call: the
       // latter registers the watch but never populates fileimportlistObj
       // for the target, relying on a later top-level fileWatcher() call

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -91,6 +91,21 @@ function buildBannerComment(banner: boolean | string): string {
 const filelist: string[] = [];
 const fileimportlist: Record<string, string[]> = {};
 
+// Undo the bookkeeping fileWatcher() records for a path, so a file that comes
+// back later is treated as new again. fileWatcher() refuses to register a path
+// already in filelist (that dedup is what keeps a file imported by several
+// others from collecting one watcher per importer), so without this a deleted
+// file's stale entry permanently blocks setupWatcher() from ever watching it
+// again: the recreate itself still compiles, via the parent directory's
+// readdir rescan, but every edit after that is silently ignored for the rest
+// of the session (issue #197 covered the transient-miss half of this; a
+// confirmed delete followed by a recreate is the other half).
+function forgetWatchedFile(f: string): void {
+  const index = filelist.indexOf(f);
+  if (index !== -1) filelist.splice(index, 1);
+  delete fileimportlist[f];
+}
+
 const lessWatchCompilerUtilsModule = {
   config: {} as LessWatchCompilerConfig,
 
@@ -515,6 +530,7 @@ const lessWatchCompilerUtilsModule = {
             const existed = !!lastKnownStat;
             delete files[f];
             fs.unwatchFile(f);
+            forgetWatchedFile(f);
             if (existed && !(options.ignoreDotFiles && path.basename(f)[0] === '.') && !(options.filter && options.filter(f))) {
               watchCallback(f, c as fs.Stats, p as fs.Stats, fileimportlist);
             }

--- a/test/api.js
+++ b/test/api.js
@@ -180,6 +180,61 @@ describe('Programmatic API (require("less-watch-compiler"))', function () {
     });
   });
 
+  it('watch() keeps transitive import tracking through a deleted and recreated middle partial', function (done) {
+    this.timeout(30000);
+    const os = require('os');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-api-transitive-'));
+    const lessDir = path.join(tmpDir, 'less');
+    const chainOutDir = path.join(tmpDir, 'css');
+    fs.mkdirSync(lessDir);
+    fs.mkdirSync(chainOutDir);
+    // main.less -> _theme.less -> colors.less, with the recreated file in the
+    // middle: its own import list is dropped when it goes away, so it has to
+    // be rebuilt on rediscovery or the chain from main.less to colors.less
+    // stays broken and only colors.css updates.
+    const colors = path.join(lessDir, 'colors.less');
+    const theme = path.join(lessDir, '_theme.less');
+    fs.writeFileSync(colors, '@brand: red;');
+    fs.writeFileSync(theme, '@import "colors"; @text: @brand;');
+    fs.writeFileSync(path.join(lessDir, 'main.less'), '@import "_theme"; .main { color: @text; }');
+    const outputCss = path.join(chainOutDir, 'main.css');
+
+    function waitFor(needle, timeoutMs, cb) {
+      const start = Date.now();
+      (function poll() {
+        fs.readFile(outputCss, 'utf8', (err, content) => {
+          if (!err && content.includes(needle)) return cb(null);
+          if (Date.now() - start > timeoutMs) return cb(new Error('timed out waiting for "' + needle + '" in ' + outputCss));
+          setTimeout(poll, 50);
+        });
+      })();
+    }
+
+    function cleanup() {
+      for (const f of [colors, theme, path.join(lessDir, 'main.less')]) fs.unwatchFile(f);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    api.watch(lessDir, chainOutDir);
+
+    waitFor('red', 6000, (err) => {
+      if (err) return (cleanup(), done(err));
+      fs.unlinkSync(theme);
+      setTimeout(() => {
+        fs.writeFileSync(theme, '@import "colors"; @text: @brand;');
+        setTimeout(() => {
+          // Edit the leaf, two hops from main.less, after the middle file
+          // has been through a full delete/recreate cycle.
+          fs.writeFileSync(colors, '@brand: green;');
+          waitFor('green', 9000, (err2) => {
+            cleanup();
+            done(err2);
+          });
+        }, 2000);
+      }, 1500);
+    });
+  });
+
   it('watch() compiles on start and recompiles the output when a watched file is later edited', function (done) {
     this.timeout(15000);
     const os = require('os');

--- a/test/api.js
+++ b/test/api.js
@@ -126,6 +126,60 @@ describe('Programmatic API (require("less-watch-compiler"))', function () {
     });
   });
 
+  it('watch() keeps recompiling importers of a hidden _partial that is deleted and recreated', function (done) {
+    this.timeout(30000);
+    const os = require('os');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-api-partial-'));
+    const lessDir = path.join(tmpDir, 'less');
+    const partialOutDir = path.join(tmpDir, 'css');
+    fs.mkdirSync(lessDir);
+    fs.mkdirSync(partialOutDir);
+    const partial = path.join(lessDir, '_shared.less');
+    const importer = path.join(lessDir, 'page.less');
+    const outputCss = path.join(partialOutDir, 'page.css');
+    fs.writeFileSync(partial, '@c: red;');
+    fs.writeFileSync(importer, '@import "_shared"; .page { color: @c; }');
+
+    function waitFor(needle, timeoutMs, cb) {
+      const start = Date.now();
+      (function poll() {
+        fs.readFile(outputCss, 'utf8', (err, content) => {
+          if (!err && content.includes(needle)) return cb(null);
+          if (Date.now() - start > timeoutMs) return cb(new Error('timed out waiting for "' + needle + '" in ' + outputCss));
+          setTimeout(poll, 50);
+        });
+      })();
+    }
+
+    function cleanup() {
+      fs.unwatchFile(partial);
+      fs.unwatchFile(importer);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    api.watch(lessDir, partialOutDir);
+
+    waitFor('red', 6000, (err) => {
+      if (err) return (cleanup(), done(err));
+      fs.unlinkSync(partial);
+      setTimeout(() => {
+        fs.writeFileSync(partial, '@c: green;');
+        // The directory rescan used to run every new entry through
+        // filterFiles(), which rejects hidden files, so a recreated
+        // underscore-prefixed partial was never rediscovered at all.
+        waitFor('green', 9000, (err2) => {
+          if (err2) return (cleanup(), done(err2));
+          // ...and it has to still be watched afterwards, not just compiled once.
+          fs.writeFileSync(partial, '@c: purple;');
+          waitFor('purple', 9000, (err3) => {
+            cleanup();
+            done(err3);
+          });
+        });
+      }, 1500);
+    });
+  });
+
   it('watch() compiles on start and recompiles the output when a watched file is later edited', function (done) {
     this.timeout(15000);
     const os = require('os');

--- a/test/api.js
+++ b/test/api.js
@@ -74,6 +74,58 @@ describe('Programmatic API (require("less-watch-compiler"))', function () {
     assert.throws(() => api.watch('test/less', 'test/css', { mainFile: 'no-such-main.less', runOnce: true }), /no-such-main\.less does not exist/);
   });
 
+  it('watch() keeps watching a file that is deleted and then recreated', function (done) {
+    this.timeout(30000);
+    const os = require('os');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lwc-api-recreate-'));
+    const lessDir = path.join(tmpDir, 'less');
+    const recreateOutDir = path.join(tmpDir, 'css');
+    fs.mkdirSync(lessDir);
+    fs.mkdirSync(recreateOutDir);
+    const lessFile = path.join(lessDir, 'gone.less');
+    const outputCss = path.join(recreateOutDir, 'gone.css');
+    fs.writeFileSync(lessFile, '.a { color: red; }');
+
+    function waitFor(needle, timeoutMs, cb) {
+      const start = Date.now();
+      (function poll() {
+        fs.readFile(outputCss, 'utf8', (err, content) => {
+          if (!err && content.includes(needle)) return cb(null);
+          if (Date.now() - start > timeoutMs) return cb(new Error('timed out waiting for "' + needle + '" in ' + outputCss));
+          setTimeout(poll, 50);
+        });
+      })();
+    }
+
+    function cleanup() {
+      fs.unwatchFile(lessFile);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+
+    api.watch(lessDir, recreateOutDir);
+
+    waitFor('red', 6000, (err) => {
+      if (err) return (cleanup(), done(err));
+      fs.unlinkSync(lessFile);
+      // Let the removal-confirmation debounce in setupWatcher() actually fire,
+      // so this exercises a confirmed delete rather than a transient miss.
+      setTimeout(() => {
+        fs.writeFileSync(lessFile, '.a { color: green; }');
+        waitFor('green', 8000, (err2) => {
+          if (err2) return (cleanup(), done(err2));
+          // The real regression: the recreate itself compiles via the parent
+          // directory rescan, but the file used to stay permanently unwatched
+          // afterwards, so every later edit was silently dropped.
+          fs.writeFileSync(lessFile, '.a { color: purple; }');
+          waitFor('purple', 8000, (err3) => {
+            cleanup();
+            done(err3);
+          });
+        });
+      }, 1500);
+    });
+  });
+
   it('watch() compiles on start and recompiles the output when a watched file is later edited', function (done) {
     this.timeout(15000);
     const os = require('os');


### PR DESCRIPTION
Fixes #

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [ ] Did you add update docs in the `README.md` file? — no user-facing behaviour is documented differently; this restores what the README already promises.

Changes proposed in this pull request:

- **Prune a deleted path from `filelist`** when its watch is torn down, so a file that comes back is treated as new again.
- **Make the directory rescan check the extension only, not `filterFiles()`**, so a recreated hidden `_partial.less` is rediscovered at all.

### The bug

A `.less` file that is deleted and then written again compiles once on the recreate and is **never watched after that**. Every later edit is silently dropped for the rest of the session — the watcher is still running, no error is printed, and the CSS just stops updating.

Reproduced against `master`:

```
initial compile (red):            true
edit before delete (blue):        true
recompile after recreate (green): true
edit AFTER recreate (purple):     false   ← silently ignored, forever
```

For a hidden partial it's worse — the recreate isn't even noticed:

```
recreate _shared.less (green):    false
edit after recreate (purple):     false
```

### Two causes, both needed for the fix

**1. `filelist` was never pruned.** `fileWatcher()` refuses to register a path already in `filelist`. That dedup is deliberate — it's what stops a file imported by several others from collecting one `fs.watchFile` listener per importer (there's an existing test for exactly that). But the removal branch of `setupWatcher()` did `delete files[f]; fs.unwatchFile(f);` without pruning the matching `filelist` entry, so the guard kept firing forever. When the parent directory's `readdir` rescan rediscovered the recreated file it still compiled it once and called `fileWatcher()` — which returned immediately at the stale guard and never reached `setupWatcher()`.

**2. The rescan rejected hidden files outright.** It ran each new entry through `options.filter`, i.e. `filterFiles()`, which rejects hidden files *as well as* disallowed extensions. Those two checks are fused there because the initial `walk()` wants both — it decides what to compile on sight, and a hidden file isn't a candidate. But when deciding what to **watch**, only the extension applies: a hidden partial has to be followed, because something else imports it and needs recompiling when it changes. This is the same distinction `fileWatcher()` already makes for `@import` targets, with a comment saying so.

Each fix in isolation, measured:

| fix | recreate recompiles | later edits recompile |
| --- | --- | --- |
| neither (`master`) | no | no |
| `filelist` prune only | no | no |
| rescan only | yes | **no** |
| **both** | **yes** | **yes** |

### Scope note

Hidden files are now watched where they previously weren't — that's the point. They still get **no standalone CSS of their own**: `compileCSS()` declines that independently and continues to. Verified explicitly — adding `_orphan.less`, `.dotfile.less` and `notes.txt` to a live watch produces no `_orphan.css`, `.dotfile.css` or `notes.css`.

This is the other half of #197: that issue covered a *transient* miss (an editor's non-atomic save briefly looking like a delete), which the existing debounce/recheck handles. This is what happens once a delete is genuinely confirmed.

### Reachability

Ordinary editing hits this: `git checkout` across branches, editors that save by delete-and-recreate rather than atomic rename, and scaffolding/codegen that rewrites files in place. `_variables.less` / `_shared.less` are the conventional LESS partial naming, so the hidden-file half is the common case rather than the exotic one.

### Testing

Two new tests in `test/api.js`, driving real `watch()` sessions through compile → edit → delete → recreate → **edit again**, one for an ordinary file and one for a hidden partial with an importer. Verified each fails without its corresponding fix and passes with it.

Full suite: 200 passing, lint/format/typecheck clean, coverage 96.86 / 88.03 / 91.80 / 96.86 against thresholds 93 / 80 / 85 / 93.

Suggested bump: **patch** (bug fix, no API or flag change).