### PR TITLE
fix(walk): stop descending into symlink loops during the directory walk

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -114,12 +114,21 @@ const lessWatchCompilerUtilsModule = {
       fs.stat(directory, (err, stat) => {
         if (err) return callback(err as NodeJS.ErrnoException, null);
 
-        const identity = String(stat.dev) + ':' + String(stat.ino);
-        if (state.seenDirs.has(identity)) {
-          state.pending -= 1;
-          return void finalize(null);
+        // Filesystems that don't report inodes -- FAT/exFAT volumes and some
+        // network shares under Windows -- hand back ino 0 for every entry. A
+        // 0 identity would match everything and skip the entire tree after
+        // the first directory, which is a far worse failure than the loop
+        // this guards against. No usable identity means no dedup: those
+        // volumes keep exactly today's behavior, and nothing is ever wrongly
+        // skipped anywhere.
+        const identity = stat.ino ? String(stat.dev) + ':' + String(stat.ino) : undefined;
+        if (identity !== undefined) {
+          if (state.seenDirs.has(identity)) {
+            state.pending -= 1;
+            return void finalize(null);
+          }
+          state.seenDirs.add(identity);
         }
-        state.seenDirs.add(identity);
 
         state.files[directory] = stat as fs.Stats;
         fs.readdir(directory, (readErr, files) => {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -95,7 +95,15 @@ const lessWatchCompilerUtilsModule = {
   config: {} as LessWatchCompilerConfig,
 
   walk(dir: string, options: WalkOptions, callback: WalkCompleteCallback, initCallback?: InitCallback): void {
-    const state = { files: {} as FilesMap, pending: 0 };
+    // seenDirs holds the identity (device + inode) of every directory already
+    // descended into. fs.stat follows symlinks, so a link pointing back at one
+    // of its own ancestors (e.g. `less/self -> ..`) otherwise makes the walk
+    // recurse into itself until the OS gives up with ELOOP -- compiling the
+    // same tree over and over into ever-deeper output folders on the way down
+    // and then killing the process with an uncaught error. Comparing dev+ino
+    // rather than the path also collapses two different symlinks that point at
+    // the same real directory, so its files are only compiled once.
+    const state = { files: {} as FilesMap, pending: 0, seenDirs: new Set<string>() };
 
     const finalize = (err: NodeJS.ErrnoException | null) => {
       if (state.pending === 0) callback(err, state.files);
@@ -105,6 +113,13 @@ const lessWatchCompilerUtilsModule = {
       state.pending += 1;
       fs.stat(directory, (err, stat) => {
         if (err) return callback(err as NodeJS.ErrnoException, null);
+
+        const identity = String(stat.dev) + ':' + String(stat.ino);
+        if (state.seenDirs.has(identity)) {
+          state.pending -= 1;
+          return void finalize(null);
+        }
+        state.seenDirs.add(identity);
 
         state.files[directory] = stat as fs.Stats;
         fs.readdir(directory, (readErr, files) => {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -95,40 +95,44 @@ const lessWatchCompilerUtilsModule = {
   config: {} as LessWatchCompilerConfig,
 
   walk(dir: string, options: WalkOptions, callback: WalkCompleteCallback, initCallback?: InitCallback): void {
-    // seenDirs holds the identity (device + inode) of every directory already
-    // descended into. fs.stat follows symlinks, so a link pointing back at one
-    // of its own ancestors (e.g. `less/self -> ..`) otherwise makes the walk
-    // recurse into itself until the OS gives up with ELOOP -- compiling the
-    // same tree over and over into ever-deeper output folders on the way down
-    // and then killing the process with an uncaught error. Comparing dev+ino
-    // rather than the path also collapses two different symlinks that point at
-    // the same real directory, so its files are only compiled once.
-    const state = { files: {} as FilesMap, pending: 0, seenDirs: new Set<string>() };
+    const state = { files: {} as FilesMap, pending: 0 };
 
     const finalize = (err: NodeJS.ErrnoException | null) => {
       if (state.pending === 0) callback(err, state.files);
     };
 
-    const processDir = (directory: string) => {
+    // `ancestors` carries the identity (device + inode) of every directory on
+    // the path from the walk root down to this one. fs.stat follows symlinks,
+    // so a link pointing back at one of its own ancestors -- `less/self -> ..`
+    // is enough -- otherwise hands the walk an infinitely deep tree, and it
+    // descends until the OS refuses with ELOOP, compiling the same files into
+    // ever-deeper output folders the whole way down.
+    //
+    // Only an ancestor repeat is a cycle, and only cycles are skipped. Two
+    // sibling symlinks pointing at the same real directory are not a cycle:
+    // collapsing those would make which of the equivalent paths survives
+    // depend on which fs.stat callback happened to land first, and with it
+    // which output path the CSS is written to -- so the same tree could
+    // compile to css/link-a/x.css on one run and css/link-b/x.css on the next.
+    // Walking each alias is what this already did, and it stays that way.
+    const processDir = (directory: string, ancestors: Set<string>) => {
       state.pending += 1;
       fs.stat(directory, (err, stat) => {
         if (err) return callback(err as NodeJS.ErrnoException, null);
 
         // Filesystems that don't report inodes -- FAT/exFAT volumes and some
-        // network shares under Windows -- hand back ino 0 for every entry. A
-        // 0 identity would match everything and skip the entire tree after
-        // the first directory, which is a far worse failure than the loop
-        // this guards against. No usable identity means no dedup: those
-        // volumes keep exactly today's behavior, and nothing is ever wrongly
-        // skipped anywhere.
+        // network shares under Windows -- hand back ino 0 for every entry,
+        // which would read as an immediate cycle and prune the whole tree
+        // below the root. That is a far worse failure than the loop this
+        // guards against, so no usable identity means no cycle detection:
+        // those volumes keep exactly today's behavior, and nothing is ever
+        // wrongly skipped anywhere.
         const identity = stat.ino ? String(stat.dev) + ':' + String(stat.ino) : undefined;
-        if (identity !== undefined) {
-          if (state.seenDirs.has(identity)) {
-            state.pending -= 1;
-            return void finalize(null);
-          }
-          state.seenDirs.add(identity);
+        if (identity !== undefined && ancestors.has(identity)) {
+          state.pending -= 1;
+          return void finalize(null);
         }
+        const childAncestors = identity === undefined ? ancestors : new Set(ancestors).add(identity);
 
         state.files[directory] = stat as fs.Stats;
         fs.readdir(directory, (readErr, files) => {
@@ -161,7 +165,7 @@ const lessWatchCompilerUtilsModule = {
 
                 state.files[filePath] = st as fs.Stats;
                 if (st.isDirectory()) {
-                  processDir(filePath);
+                  processDir(filePath, childAncestors);
                 } else {
                   if (initCallback) initCallback(filePath);
                 }
@@ -177,7 +181,7 @@ const lessWatchCompilerUtilsModule = {
       });
     };
 
-    processDir(dir);
+    processDir(dir, new Set());
   },
 
   watchTree(root: string, options: WalkOptions | WatchCallback, watchCallback?: WatchCallback, initCallback?: InitCallback): void {

--- a/test/less-watch-compiler.js
+++ b/test/less-watch-compiler.js
@@ -133,14 +133,21 @@ describe('The CLI should', function () {
   });
 
   describe('survive a hostile watch tree:', function () {
-    it('a symlink loop does not crash the run or flood the output folder', () => {
+    it('a symlink loop does not crash the run or flood the output folder', function () {
       const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-cli-loop-'));
       try {
         fs.mkdirSync(path.join(tmpDir, 'less'));
         fs.writeFileSync(path.join(tmpDir, 'less', 'a.less'), '.a { color: red; }');
         // less/loop -> the folder containing less/, so the walk can reach
-        // less/loop/less/loop/... without limit.
-        fs.symlinkSync(tmpDir, path.join(tmpDir, 'less', 'loop'), 'dir');
+        // less/loop/less/loop/... without limit. Creating a symlink needs a
+        // privilege an ordinary Windows shell lacks; the walk is what's under
+        // test, so skip there rather than fail.
+        try {
+          fs.symlinkSync(tmpDir, path.join(tmpDir, 'less', 'loop'), 'dir');
+        } catch (err) {
+          if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOSYS' || err.code === 'ENOTSUP') return this.skip();
+          throw err;
+        }
 
         cli('--run-once', path.join(tmpDir, 'less'), path.join(tmpDir, 'css'));
 

--- a/test/less-watch-compiler.js
+++ b/test/less-watch-compiler.js
@@ -131,6 +131,27 @@ describe('The CLI should', function () {
       });
     });
   });
+
+  describe('survive a hostile watch tree:', function () {
+    it('a symlink loop does not crash the run or flood the output folder', () => {
+      const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-cli-loop-'));
+      try {
+        fs.mkdirSync(path.join(tmpDir, 'less'));
+        fs.writeFileSync(path.join(tmpDir, 'less', 'a.less'), '.a { color: red; }');
+        // less/loop -> the folder containing less/, so the walk can reach
+        // less/loop/less/loop/... without limit.
+        fs.symlinkSync(tmpDir, path.join(tmpDir, 'less', 'loop'), 'dir');
+
+        cli('--run-once', path.join(tmpDir, 'less'), path.join(tmpDir, 'css'));
+
+        assert.ok(fs.existsSync(path.join(tmpDir, 'css', 'a.css')), 'the real file must still compile');
+        const dirs = fs.readdirSync(path.join(tmpDir, 'css'), { withFileTypes: true }).filter((e) => e.isDirectory());
+        assert.equal(dirs.length, 0, 'following the loop must not create nested output directories');
+      } finally {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
 });
 
 function cli(...args) {

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -6,6 +6,21 @@ var assert = require('assert'),
   testroot = cwd + '/test/less/',
   testRelative = './test/less';
 
+// fs.symlinkSync needs SeCreateSymbolicLinkPrivilege on Windows, which an
+// ordinary developer shell doesn't have. What's under test is how walk()
+// behaves once such a link exists, not the ability to create one, so report
+// the failure to the caller and let it skip rather than fail the suite on
+// machines where links can't be made at all.
+function trySymlink(target, linkPath, type) {
+  try {
+    fs.symlinkSync(target, linkPath, type);
+    return true;
+  } catch (err) {
+    if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOSYS' || err.code === 'ENOTSUP') return false;
+    throw err;
+  }
+}
+
 describe('lessWatchCompilerUtils Module API', function () {
   describe("Should have the following API's", function () {
     describe('walk()', function () {
@@ -72,13 +87,16 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
-      it('does not descend into a symlink loop, and still finds the real files', (done) => {
+      it('does not descend into a symlink loop, and still finds the real files', function (done) {
         const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-loop-'));
         fs.writeFileSync(path.join(tmpDir, 'real.less'), '');
         // A link back into its own tree: fs.stat follows symlinks, so an
         // unguarded walk recurses tmpDir/loop/loop/... until the OS refuses
         // with ELOOP, and that error takes down the whole walk.
-        fs.symlinkSync(tmpDir, path.join(tmpDir, 'loop'), 'dir');
+        if (!trySymlink(tmpDir, path.join(tmpDir, 'loop'), 'dir')) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          return this.skip();
+        }
 
         lessWatchCompilerUtils.walk(
           tmpDir,
@@ -102,22 +120,32 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
-      it('visits a directory once even when two different symlinks point at it', (done) => {
-        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-dup-'));
+      it('walks every alias of a directory, so which path survives is never a race', function (done) {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-alias-'));
         const realDir = path.join(tmpDir, 'real');
         fs.mkdirSync(realDir);
         fs.writeFileSync(path.join(realDir, 'once.less'), '');
-        fs.symlinkSync(realDir, path.join(tmpDir, 'link-a'), 'dir');
-        fs.symlinkSync(realDir, path.join(tmpDir, 'link-b'), 'dir');
+        if (!trySymlink(realDir, path.join(tmpDir, 'link-a'), 'dir') || !trySymlink(realDir, path.join(tmpDir, 'link-b'), 'dir')) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          return this.skip();
+        }
 
+        // Sibling aliases are not a cycle. Collapsing them to one would leave
+        // the surviving path decided by whichever fs.stat callback landed
+        // first -- and resolveOutputPath() derives the output path from it, so
+        // the same tree would compile to css/link-a/once.css on one run and
+        // css/link-b/once.css on the next.
         lessWatchCompilerUtils.walk(
           tmpDir,
           {},
           (err, files) => {
             try {
               assert.ifError(err);
-              const compilable = Object.keys(files).filter((f) => f.endsWith('once.less'));
-              assert.equal(compilable.length, 1, 'the same real file must not be queued for compilation through every symlink to it');
+              const via = Object.keys(files)
+                .filter((f) => f.endsWith('once.less'))
+                .map((f) => path.basename(path.dirname(f)))
+                .sort();
+              assert.deepEqual(via, ['link-a', 'link-b', 'real'], 'every alias must be walked, not whichever one won the race');
               fs.rmSync(tmpDir, { recursive: true, force: true });
               done();
             } catch (e) {

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -128,6 +128,46 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
+      it('still walks the whole tree on a filesystem that reports no inode numbers', (done) => {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-noino-'));
+        for (const d of ['one', 'two', 'three']) {
+          fs.mkdirSync(path.join(tmpDir, d));
+          fs.writeFileSync(path.join(tmpDir, d, d + '.less'), '');
+        }
+
+        // FAT/exFAT volumes and some Windows network shares report ino 0 for
+        // every entry. Deduping on a 0 identity would match everything and
+        // silently skip the entire tree after the first directory.
+        const originalStat = fs.stat;
+        fs.stat = function (target, cb) {
+          return originalStat(target, (err, stat) => {
+            if (stat) stat.ino = 0;
+            cb(err, stat);
+          });
+        };
+
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          (err, files) => {
+            fs.stat = originalStat;
+            try {
+              assert.ifError(err);
+              const found = Object.keys(files)
+                .filter((f) => f.endsWith('.less'))
+                .map((f) => path.basename(f))
+                .sort();
+              assert.deepEqual(found, ['one.less', 'three.less', 'two.less'], 'every directory must still be walked when identities are unavailable');
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done();
+            } catch (e) {
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done(e);
+            }
+          },
+          function () {}
+        );
+      });
     });
     describe('watchTree()', function () {
       it('watchTree() function should be there', function () {

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -72,6 +72,62 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
+      it('does not descend into a symlink loop, and still finds the real files', (done) => {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-loop-'));
+        fs.writeFileSync(path.join(tmpDir, 'real.less'), '');
+        // A link back into its own tree: fs.stat follows symlinks, so an
+        // unguarded walk recurses tmpDir/loop/loop/... until the OS refuses
+        // with ELOOP, and that error takes down the whole walk.
+        fs.symlinkSync(tmpDir, path.join(tmpDir, 'loop'), 'dir');
+
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          (err, files) => {
+            try {
+              assert.ifError(err);
+              const fileList = Object.keys(files);
+              assert.ok(
+                fileList.some((f) => f.endsWith('real.less')),
+                'the real file must still be discovered'
+              );
+              assert.ok(!fileList.some((f) => f.includes(`loop${path.sep}loop`)), 'the walk must not re-enter a directory it has already visited');
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done();
+            } catch (e) {
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done(e);
+            }
+          },
+          function () {}
+        );
+      });
+      it('visits a directory once even when two different symlinks point at it', (done) => {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-dup-'));
+        const realDir = path.join(tmpDir, 'real');
+        fs.mkdirSync(realDir);
+        fs.writeFileSync(path.join(realDir, 'once.less'), '');
+        fs.symlinkSync(realDir, path.join(tmpDir, 'link-a'), 'dir');
+        fs.symlinkSync(realDir, path.join(tmpDir, 'link-b'), 'dir');
+
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          (err, files) => {
+            try {
+              assert.ifError(err);
+              const compilable = Object.keys(files).filter((f) => f.endsWith('once.less'));
+              assert.equal(compilable.length, 1, 'the same real file must not be queued for compilation through every symlink to it');
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done();
+            } catch (e) {
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done(e);
+            }
+          },
+          function () {}
+        );
+      });
     });
     describe('watchTree()', function () {
       it('watchTree() function should be there', function () {


### PR DESCRIPTION
Fixes #

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [ ] Did you add update docs in the `README.md` file? — not needed; no documented behaviour changes.

Changes proposed in this pull request:

- **Track the directory identities on the path from the walk root down to the current directory, and skip when one repeats** — so a symlink cycle can't send the walk into itself.

### The bug

`walk()` resolves entries with `fs.stat`, which follows symlinks. A link pointing back into its own tree — `less/loop -> ..` is enough — gives the walk an infinitely deep directory tree, and it descends it: `less/loop/less/loop/…` until the OS refuses at ~40 levels with `ELOOP`, which `watchTree()` then rethrows from inside an fs callback as an uncaught error.

The crash isn't the worst part. Every level on the way down looks like a legitimate directory of `.less` files, so **each one gets compiled into a correspondingly nested output directory**. A one-file project on `master`:

```
$ less-watch-compiler --run-once less css
Running less-watch-compiler once.
ELOOP
.../lessWatchCompilerUtils.js:118
                throw err;
[Error: ELOOP: too many symbolic links encountered, stat '.../less/loop/less/loop/less/loop/...']

$ find css -type d | wc -l
79
```

With this PR, same project: 1 directory, 1 CSS file, exit 0.

### Only cycles are skipped

An earlier revision deduplicated on *every* directory already visited. Review caught that this quietly changes behaviour for aliases that aren't cycles at all: with `real/`, `link-a -> real` and `link-b -> real`, the surviving path is whichever sibling `fs.stat` callback lands first — and `resolveOutputPath()` derives the output path from it. Measured over 40 runs of that revision:

```
link-a  34
link-b   4
real     2
```

…so the same tree would compile to `css/link-a/once.css` on one run and `css/real/once.css` on the next. Trading duplicate output for non-deterministic output is a bad deal.

Only an **ancestor** repeat is a genuine cycle. Sibling aliases are now walked exactly as they are on `master` — no dedup, nothing to race over — while `less/self -> ..` is still caught at the first repeat. Same 40 runs after: all three paths discovered, every time.

Aliased directories are still recorded and watched, unchanged from `master`. Live-watch behaviour for aliases is out of scope here; this PR only stops the walk recursing into itself.

### Filesystems without inodes

`FAT`/`exFAT` volumes and some Windows network shares report `ino: 0` for every entry. A zero identity would read as an immediate cycle and prune the whole tree below the root — a far worse failure than the loop this guards against. No usable identity means no cycle detection: those volumes keep exactly today's behaviour, and nothing is ever wrongly skipped. Tested by stubbing `fs.stat` to force `ino: 0`.

### Testing

Four tests, each verified failing against the version it guards:

- `walk()` on a self-referential symlink finds the real file and never re-enters a visited directory.
- `walk()` visits every alias of a shared real directory, so which path survives is never a race.
- `walk()` still walks the whole tree when the filesystem reports no inode numbers.
- End-to-end CLI run over a looping tree: exits cleanly, compiles the real file, creates no nested output directories.

Symlink fixtures `skip()` rather than fail where the platform won't create links (Windows needs `SeCreateSymbolicLinkPrivilege`).

Full suite: 202 passing, lint/format/typecheck clean, coverage 96.85 / 87.93 / 91.52 / 96.85 against thresholds 93 / 80 / 85 / 93.

### Note for sequencing

Touches `walk()`'s `processDir`, as does #251. Verified they compose: the **source auto-merges cleanly** and the combined result handles a tree containing a symlink loop, a dangling symlink and a mutual-`ELOOP` pair at once. Only the test file conflicts, from both branches appending tests at the same spot.

Suggested bump: **patch** (bug fix, no API or flag change).