### PR TITLE
fix(walk): skip path-local failures instead of aborting the whole walk

### DIFF
--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -101,15 +101,33 @@ const lessWatchCompilerUtilsModule = {
       if (state.pending === 0) callback(err, state.files);
     };
 
-    const processDir = (directory: string) => {
+    // Only the root directory's failure aborts the walk: the caller named that
+    // path specifically, so there's nothing sensible to fall back to. A
+    // failure deeper in the tree -- an unreadable directory, a symlink the OS
+    // won't resolve -- is reported and stepped over instead, so one bad entry
+    // can't take down the whole watch session over an otherwise fine tree.
+    //
+    // Aborting also used to leave `pending` un-decremented while the rest of
+    // the walk carried on, so a later finalize() could invoke `callback` a
+    // second time, after it had already been called with the error.
+    const skipOrAbort = (err: NodeJS.ErrnoException, target: string, isRoot: boolean): void => {
+      if (isRoot) return callback(err, null);
+      console.log('Skipping ' + target + ': ' + (err.code || err.message));
+      finalize(null);
+    };
+
+    const processDir = (directory: string, isRoot: boolean) => {
       state.pending += 1;
       fs.stat(directory, (err, stat) => {
-        if (err) return callback(err as NodeJS.ErrnoException, null);
+        if (err) {
+          state.pending -= 1;
+          return skipOrAbort(err as NodeJS.ErrnoException, directory, isRoot);
+        }
 
         state.files[directory] = stat as fs.Stats;
         fs.readdir(directory, (readErr, files) => {
           state.pending -= 1;
-          if (readErr) return callback(readErr as NodeJS.ErrnoException, null);
+          if (readErr) return skipOrAbort(readErr as NodeJS.ErrnoException, directory, isRoot);
 
           files.forEach((entry) => {
             const filePath = path.join(directory, entry);
@@ -118,8 +136,8 @@ const lessWatchCompilerUtilsModule = {
               let enoent = false;
               if (statErr) {
                 if ((statErr as NodeJS.ErrnoException).code !== 'ENOENT') {
-                  console.log((statErr as NodeJS.ErrnoException).code);
-                  return callback(statErr as NodeJS.ErrnoException, null);
+                  state.pending -= 1;
+                  return skipOrAbort(statErr as NodeJS.ErrnoException, filePath, false);
                 } else {
                   enoent = true;
                 }
@@ -137,7 +155,7 @@ const lessWatchCompilerUtilsModule = {
 
                 state.files[filePath] = st as fs.Stats;
                 if (st.isDirectory()) {
-                  processDir(filePath);
+                  processDir(filePath, false);
                 } else {
                   if (initCallback) initCallback(filePath);
                 }
@@ -153,7 +171,7 @@ const lessWatchCompilerUtilsModule = {
       });
     };
 
-    processDir(dir);
+    processDir(dir, true);
   },
 
   watchTree(root: string, options: WalkOptions | WatchCallback, watchCallback?: WatchCallback, initCallback?: InitCallback): void {

--- a/src/lib/lessWatchCompilerUtils.ts
+++ b/src/lib/lessWatchCompilerUtils.ts
@@ -97,21 +97,39 @@ const lessWatchCompilerUtilsModule = {
   walk(dir: string, options: WalkOptions, callback: WalkCompleteCallback, initCallback?: InitCallback): void {
     const state = { files: {} as FilesMap, pending: 0 };
 
-    const finalize = (err: NodeJS.ErrnoException | null) => {
-      if (state.pending === 0) callback(err, state.files);
+    // walk() settles once. Several entries can fail in the same pass -- under
+    // descriptor exhaustion most of them will -- and each of those used to
+    // reach `callback` on its own, so the caller was handed the same walk two
+    // or ten times over. watchTree() would go on to register watchers against
+    // a files map it had already thrown on.
+    let settled = false;
+    const settle = (err: NodeJS.ErrnoException | null, files: FilesMap | null) => {
+      if (settled) return;
+      settled = true;
+      callback(err, files);
     };
 
-    // Only the root directory's failure aborts the walk: the caller named that
-    // path specifically, so there's nothing sensible to fall back to. A
-    // failure deeper in the tree -- an unreadable directory, a symlink the OS
-    // won't resolve -- is reported and stepped over instead, so one bad entry
-    // can't take down the whole watch session over an otherwise fine tree.
+    const finalize = (err: NodeJS.ErrnoException | null) => {
+      if (state.pending === 0) settle(err, state.files);
+    };
+
+    // A failure deeper in the tree is skipped rather than fatal -- but only
+    // when it's a property of that path. These codes mean the entry itself is
+    // genuinely unusable while the rest of the tree is unaffected, so stepping
+    // over it is right and the walk still returns everything else.
     //
-    // Aborting also used to leave `pending` un-decremented while the rest of
-    // the walk carried on, so a later finalize() could invoke `callback` a
-    // second time, after it had already been called with the error.
+    // Anything else -- EMFILE/ENFILE from descriptor exhaustion, ENOMEM, an
+    // EIO off a failing disk -- is a condition of the process or the machine,
+    // not of this path. Under descriptor pressure most of the tree fails the
+    // same way, and quietly reporting a successful partial walk would bring
+    // the watcher up over a fraction of the files with nothing to say so.
+    // Those propagate, exactly like a bad root.
+    const pathLocalErrorCodes = new Set(['ENOENT', 'EACCES', 'EPERM', 'ELOOP', 'ENOTDIR', 'ENAMETOOLONG', 'EINVAL']);
+
     const skipOrAbort = (err: NodeJS.ErrnoException, target: string, isRoot: boolean): void => {
-      if (isRoot) return callback(err, null);
+      // The root is the path the caller named specifically, so there's nothing
+      // sensible to fall back to when it fails, whatever the reason.
+      if (isRoot || !pathLocalErrorCodes.has(err.code as string)) return settle(err, null);
       console.log('Skipping ' + target + ': ' + (err.code || err.message));
       finalize(null);
     };

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -6,6 +6,21 @@ var assert = require('assert'),
   testroot = cwd + '/test/less/',
   testRelative = './test/less';
 
+// fs.symlinkSync needs SeCreateSymbolicLinkPrivilege on Windows, which an
+// ordinary developer shell doesn't have. What's under test is how walk()
+// behaves once such a link exists, not the ability to create one, so report
+// the failure to the caller and let it skip rather than fail the suite on
+// machines where links can't be made at all.
+function trySymlink(target, linkPath, type) {
+  try {
+    fs.symlinkSync(target, linkPath, type);
+    return true;
+  } catch (err) {
+    if (err.code === 'EPERM' || err.code === 'EACCES' || err.code === 'ENOSYS' || err.code === 'ENOTSUP') return false;
+    throw err;
+  }
+}
+
 describe('lessWatchCompilerUtils Module API', function () {
   describe("Should have the following API's", function () {
     describe('walk()', function () {
@@ -84,13 +99,15 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
-      it('steps over an unreadable entry deeper in the tree instead of aborting the whole walk', (done) => {
+      it('steps over an unreadable entry deeper in the tree instead of aborting the whole walk', function (done) {
         const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-badentry-'));
         fs.writeFileSync(path.join(tmpDir, 'good.less'), '');
         // A pair of symlinks pointing at each other: stat fails with ELOOP,
         // which is neither ENOENT nor anything the walk can act on.
-        fs.symlinkSync(path.join(tmpDir, 'b'), path.join(tmpDir, 'a'));
-        fs.symlinkSync(path.join(tmpDir, 'a'), path.join(tmpDir, 'b'));
+        if (!trySymlink(path.join(tmpDir, 'b'), path.join(tmpDir, 'a')) || !trySymlink(path.join(tmpDir, 'a'), path.join(tmpDir, 'b'))) {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          return this.skip();
+        }
 
         lessWatchCompilerUtils.walk(
           tmpDir,
@@ -112,14 +129,16 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
-      it('calls its completion callback exactly once when an entry fails to stat', (done) => {
+      it('calls its completion callback exactly once when an entry fails to stat', function (done) {
         const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-once-'));
         // Several unresolvable entries alongside real ones: aborting on the
         // first without settling its pending count let a later finalize()
         // invoke the callback again, after it had already fired with an error.
         for (const name of ['x', 'y', 'z']) {
-          fs.symlinkSync(path.join(tmpDir, name + '2'), path.join(tmpDir, name));
-          fs.symlinkSync(path.join(tmpDir, name), path.join(tmpDir, name + '2'));
+          if (!trySymlink(path.join(tmpDir, name + '2'), path.join(tmpDir, name)) || !trySymlink(path.join(tmpDir, name), path.join(tmpDir, name + '2'))) {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+            return this.skip();
+          }
         }
         fs.writeFileSync(path.join(tmpDir, 'good.less'), '');
 
@@ -142,6 +161,51 @@ describe('lessWatchCompilerUtils Module API', function () {
             done(e);
           }
         }, 500);
+      });
+      it('propagates a systemic failure like EMFILE instead of reporting a partial walk', function (done) {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-emfile-'));
+        fs.mkdirSync(path.join(tmpDir, 'sub'));
+        fs.writeFileSync(path.join(tmpDir, 'sub', 'nested.less'), '');
+        fs.writeFileSync(path.join(tmpDir, 'top.less'), '');
+
+        // Descriptor exhaustion is a condition of the process, not of this
+        // path: most of the tree fails the same way, so skipping it and
+        // returning "success" would bring a watcher up over a fraction of the
+        // files with nothing to say so.
+        const originalReaddir = fs.readdir;
+        fs.readdir = function (target, cb) {
+          if (String(target).endsWith('sub')) {
+            const err = new Error('EMFILE: too many open files');
+            err.code = 'EMFILE';
+            return process.nextTick(() => cb(err));
+          }
+          return originalReaddir(target, cb);
+        };
+
+        let calls = 0;
+        let reported = null;
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          (err) => {
+            calls += 1;
+            reported = err;
+          },
+          function () {}
+        );
+
+        setTimeout(() => {
+          fs.readdir = originalReaddir;
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          try {
+            assert.equal(calls, 1, 'walk() must still settle exactly once');
+            assert.ok(reported, 'descriptor exhaustion must not be reported as a successful walk');
+            assert.equal(reported.code, 'EMFILE');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }, 400);
       });
     });
     describe('watchTree()', function () {

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -162,6 +162,49 @@ describe('lessWatchCompilerUtils Module API', function () {
           }
         }, 500);
       });
+      it('keeps an unreadable directory in the files map, so it is still watched and can recover', function (done) {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-eacces-'));
+        const lockedDir = path.join(tmpDir, 'locked');
+        fs.mkdirSync(lockedDir);
+        fs.writeFileSync(path.join(tmpDir, 'top.less'), '');
+
+        const originalReaddir = fs.readdir;
+        fs.readdir = function (target, cb) {
+          if (String(target) === lockedDir) {
+            const err = new Error('EACCES: permission denied');
+            err.code = 'EACCES';
+            return process.nextTick(() => cb(err));
+          }
+          return originalReaddir(target, cb);
+        };
+
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          (err, files) => {
+            fs.readdir = originalReaddir;
+            try {
+              assert.ifError(err);
+              // watchTree() only watches paths present in this map. Dropping
+              // the directory because its contents couldn't be listed would
+              // leave nothing watching it, so the subtree could never be
+              // picked up even after permissions are restored -- keeping it
+              // is what lets the directory rescan recover the whole subtree.
+              assert.ok(files[lockedDir], 'an unreadable directory must stay watchable so its contents can be found later');
+              assert.ok(
+                Object.keys(files).some((f) => f.endsWith('top.less')),
+                'the rest of the tree must still be walked'
+              );
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done();
+            } catch (e) {
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done(e);
+            }
+          },
+          function () {}
+        );
+      });
       it('propagates a systemic failure like EMFILE instead of reporting a partial walk', function (done) {
         const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-emfile-'));
         fs.mkdirSync(path.join(tmpDir, 'sub'));

--- a/test/lessWatchCompilerUtils.js
+++ b/test/lessWatchCompilerUtils.js
@@ -72,6 +72,77 @@ describe('lessWatchCompilerUtils Module API', function () {
           function () {}
         );
       });
+      it('reports a bad root directory through the callback instead of walking a partial tree', (done) => {
+        lessWatchCompilerUtils.walk(
+          path.join(cwd, 'test', 'no-such-directory-at-all'),
+          {},
+          (err) => {
+            assert.ok(err, 'a missing root must surface as an error');
+            assert.equal(err.code, 'ENOENT');
+            done();
+          },
+          function () {}
+        );
+      });
+      it('steps over an unreadable entry deeper in the tree instead of aborting the whole walk', (done) => {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-badentry-'));
+        fs.writeFileSync(path.join(tmpDir, 'good.less'), '');
+        // A pair of symlinks pointing at each other: stat fails with ELOOP,
+        // which is neither ENOENT nor anything the walk can act on.
+        fs.symlinkSync(path.join(tmpDir, 'b'), path.join(tmpDir, 'a'));
+        fs.symlinkSync(path.join(tmpDir, 'a'), path.join(tmpDir, 'b'));
+
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          (err, files) => {
+            try {
+              assert.ifError(err);
+              assert.ok(
+                Object.keys(files).some((f) => f.endsWith('good.less')),
+                'the rest of the tree must still be walked'
+              );
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done();
+            } catch (e) {
+              fs.rmSync(tmpDir, { recursive: true, force: true });
+              done(e);
+            }
+          },
+          function () {}
+        );
+      });
+      it('calls its completion callback exactly once when an entry fails to stat', (done) => {
+        const tmpDir = fs.mkdtempSync(path.join(cwd, 'test/tmp-walk-once-'));
+        // Several unresolvable entries alongside real ones: aborting on the
+        // first without settling its pending count let a later finalize()
+        // invoke the callback again, after it had already fired with an error.
+        for (const name of ['x', 'y', 'z']) {
+          fs.symlinkSync(path.join(tmpDir, name + '2'), path.join(tmpDir, name));
+          fs.symlinkSync(path.join(tmpDir, name), path.join(tmpDir, name + '2'));
+        }
+        fs.writeFileSync(path.join(tmpDir, 'good.less'), '');
+
+        let calls = 0;
+        lessWatchCompilerUtils.walk(
+          tmpDir,
+          {},
+          () => {
+            calls += 1;
+          },
+          function () {}
+        );
+
+        setTimeout(() => {
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          try {
+            assert.equal(calls, 1, 'walk() must settle exactly once, not once per failing entry');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        }, 500);
+      });
     });
     describe('watchTree()', function () {
       it('watchTree() function should be there', function () {


### PR DESCRIPTION
Fixes #

- [x] Did you add adequate test and make sure they pass by running `npm run test`
- [ ] Did you add update docs in the `README.md` file? — not needed; no documented behaviour changes.

Changes proposed in this pull request:

- **A failure on one entry no longer aborts the walk** — but only when it's a property of that path.
- **Systemic failures still propagate**, rather than being reported as a successful partial walk.
- **`walk()` settles exactly once**, structurally.

### The bug

Any fs error below the root aborted the entire directory walk. One unreadable directory, or a symlink the OS won't resolve, was enough to stop the walk over an otherwise perfectly good tree. And because `watchTree()` rethrows a walk error from inside an fs callback, it surfaced as an uncaught exception rather than anything a caller could handle.

Only the root's failure is genuinely fatal — the caller named that path, so there's nothing sensible to fall back to. Path-local failures below it are now reported (`Skipping <path>: ELOOP`) and stepped over, and the rest of the tree is still discovered and watched.

### Path-local vs systemic

Review caught that skipping *every* non-root failure reintroduces the same silent failure one level up. `EMFILE`/`ENFILE` come from descriptor exhaustion, `ENOMEM` from memory pressure, `EIO` off a failing disk — when one directory fails that way, most of the tree is failing the same way, and reporting success would bring the watcher up over a fraction of the files with nothing to say so.

Skipping is limited to an allowlist — `ENOENT`, `EACCES`, `EPERM`, `ELOOP`, `ENOTDIR`, `ENAMETOOLONG`, `EINVAL` — where the entry is genuinely unusable and the rest of the tree is unaffected. Everything else propagates, exactly like a bad root. Unknown codes propagate too, which is the safer default for a change whose point is not swallowing things.

### Settling once

The old abort paths called `callback` *without* settling that entry's `pending` count:

```js
if (statErr) {
  if (statErr.code !== 'ENOENT') {
    console.log(statErr.code);
    return callback(statErr, null);   // pending never decremented
  }
```

Two bad entries meant two calls. Mocha caught it against the pre-fix code:

```
Error: done() called multiple times in test <... steps over an unreadable entry ...>;
in addition, done() received error: AssertionError: ifError got unwanted exception:
ELOOP: too many symbolic links encountered
```

In the CLI it meant `watchTree()` could register watchers over a files map it had already thrown on. Every exit now routes through a `settle()` that fires once, so "one error, one callback" holds structurally rather than depending on the pending count — which matters because systemic failures arrive in bunches by their nature.

### An unreadable directory stays in the files map

Deliberate, and load-bearing. `watchTree()` watches only paths present in that map, so dropping the directory would leave nothing watching it and the subtree could never be discovered — including after the permissions that caused the failure are lifted. Keeping it is what makes recovery possible. With `readdir` stubbed to fail with `EACCES` and then allowed again:

```
1. after walk with locked dir unreadable, css: [ 'top.css' ]
2. after access restored + new file,      css: [ 'locked', 'top.css' ]
```

Pinned by a test so it doesn't get tidied away later.

### Testing

Five tests added by this PR:

- steps over an unreadable entry deeper in the tree — failed on the pre-fix code (twice over, via the double-callback).
- calls its completion callback exactly once when an entry fails to stat — failed on the pre-fix code.
- propagates a systemic failure like `EMFILE` instead of reporting a partial walk — failed against the first revision of this PR.
- keeps an unreadable directory in the files map, so it is still watched and can recover.
- reports a bad root directory through the callback — characterization test; locks in behaviour that must not regress while the surrounding error handling changes.

Symlink fixtures `skip()` rather than fail where the platform won't create links (Windows needs `SeCreateSymbolicLinkPrivilege`).

Full suite on the merged branch: **210 passing**, lint/format/typecheck clean, coverage 97.29 / 88.09 / 92.06 / 97.29 against thresholds 93 / 80 / 85 / 93.

### Rebased on #249 + #250 — conflicts resolved

Both landed while this was open, and #250 rewrote the same function this PR changes. `master` is merged in and both conflicts resolved:

**`processDir()` gained a parameter from each side** — this PR's `isRoot`, #250's `ancestors` set for cycle detection. Both kept. `isRoot` stays a **separate parameter rather than being inferred from an empty `ancestors` set**: on a filesystem that reports no inodes, #250 deliberately leaves that set empty all the way down, so every directory would look like the root and a skippable failure deep in the tree would abort the whole walk — reintroducing this PR's bug on exactly the volumes #250's own guard protects. Ordering inside `processDir` is unchanged from each side.

**The test file** — both branches appended `walk()` tests and an identical `trySymlink` helper. All 12 tests kept, one copy of the helper.

Verified the two behaviours coexist rather than merely compiling together:

```
1. EMFILE: calls= 1 err= EMFILE            (systemic failure still propagates, once)
2. aliases walked: [ link-a, link-b, real ] (sibling aliases still all walked)
   cycle not re-entered: true               (ancestor cycle still skipped)
```

…and a CLI run over a tree containing a cycle, a dangling symlink and a mutual-`ELOOP` pair compiles its real files and exits 0.

Suggested bump: **patch** (bug fix, no API or flag change).